### PR TITLE
Prevent recreation of compute_instance_template on every apply

### DIFF
--- a/modules/vault-cluster/main.tf
+++ b/modules/vault-cluster/main.tf
@@ -61,6 +61,8 @@ resource "google_compute_instance_template" "vault_public" {
     source_image = "${var.source_image}"
     disk_size_gb = "${var.root_volume_disk_size_gb}"
     disk_type    = "${var.root_volume_disk_type}"
+    # Needed so that the instance template isn't replaced on each deploy.
+    device_name  = "persistent-disk-0"
   }
 
   network_interface {
@@ -114,6 +116,8 @@ resource "google_compute_instance_template" "vault_private" {
     boot         = true
     auto_delete  = true
     source_image = "${var.source_image}"
+    # Needed so that the instance template isn't replaced on each deploy.
+    device_name  = "persistent-disk-0"
   }
 
   network_interface {


### PR DESCRIPTION
The `device_name` was always empty so I explicitly set it to the computed value to prevent Terraform recreating it on each apply. This might be a bug in the Google provider, but I haven't found an issue for it yet.