### PR TITLE
Allow for custom service account email and scopes

### DIFF
--- a/modules/vault-cluster/main.tf
+++ b/modules/vault-cluster/main.tf
@@ -74,11 +74,15 @@ resource "google_compute_instance_template" "vault_public" {
 
   # For a full list of oAuth 2.0 Scopes, see https://developers.google.com/identity/protocols/googlescopes
   service_account {
-    scopes = [
-      "https://www.googleapis.com/auth/userinfo.email",
-      "https://www.googleapis.com/auth/compute.readonly",
-      "https://www.googleapis.com/auth/devstorage.read_write"
-    ]
+    email  = "${var.service_account_email}"
+    scopes = ["${concat(
+      list(
+        "https://www.googleapis.com/auth/userinfo.email",
+        "https://www.googleapis.com/auth/compute.readonly",
+        "https://www.googleapis.com/auth/devstorage.read_write"
+      ),
+      var.service_account_scopes
+    )}"]
   }
 
   # Per Terraform Docs (https://www.terraform.io/docs/providers/google/r/compute_instance_template.html#using-with-instance-group-manager),
@@ -122,11 +126,15 @@ resource "google_compute_instance_template" "vault_private" {
 
   # For a full list of oAuth 2.0 Scopes, see https://developers.google.com/identity/protocols/googlescopes
   service_account {
-    scopes = [
-      "https://www.googleapis.com/auth/userinfo.email",
-      "https://www.googleapis.com/auth/compute.readonly",
-      "https://www.googleapis.com/auth/devstorage.read_write"
-    ]
+    email  = "${var.service_account_email}"
+    scopes = ["${concat(
+      list(
+        "https://www.googleapis.com/auth/userinfo.email",
+        "https://www.googleapis.com/auth/compute.readonly",
+        "https://www.googleapis.com/auth/devstorage.read_write"
+      ),
+      var.service_account_scopes
+    )}"]
   }
 
   # Per Terraform Docs (https://www.terraform.io/docs/providers/google/r/compute_instance_template.html#using-with-instance-group-manager),
@@ -243,4 +251,3 @@ data "template_file" "compute_instance_template_self_link" {
   # - Take the first element of list-of-1-value
   template = "${element(concat(google_compute_instance_template.vault_public.*.self_link, google_compute_instance_template.vault_private.*.self_link), 0)}"
 }
-

--- a/modules/vault-cluster/variables.tf
+++ b/modules/vault-cluster/variables.tf
@@ -75,6 +75,17 @@ variable "custom_tags" {
   default = []
 }
 
+variable "service_account_scopes" {
+  description = "A list of service account scopes that will be added to the Compute Instance Template in addition to the scopes automatically added by this module."
+  type = "list"
+  default = []
+}
+
+variable "service_account_email" {
+  description = "The email of the service account for the instance template. If none is provided the google cloud provider project service account is used."
+  default     = ""
+}
+
 variable "instance_group_update_strategy" {
   description = "The update strategy to be used by the Instance Group. IMPORTANT! When you update almost any cluster setting, under the hood, this module creates a new Instance Group Template. Once that Instance Group Template is created, the value of this variable determines how the new Template will be rolled out across the Instance Group. Unfortunately, as of August 2017, Google only supports the options 'RESTART' (instantly restart all Compute Instances and launch new ones from the new Template) or 'NONE' (do nothing; updates should be handled manually). Google does offer a rolling updates feature that perfectly meets our needs, but this is in Alpha (https://goo.gl/MC3mfc). Therefore, until this module supports a built-in rolling update strategy, we recommend using `NONE` and either using the alpha rolling updates strategy to roll out new Vault versions, or to script this using GCE API calls. If using the alpha feature, be sure you are comfortable with the level of risk you are taking on. For additional detail, see https://goo.gl/hGH6dd."
   default = "NONE"


### PR DESCRIPTION
This enhancement allows setting a custom service account email and custom scopes for the Vault `compute_instance_template`. It adds the variables `service_account_email` and `service_account_scopes`. This variable naming matches the module [Google Managed Instance Group](https://github.com/GoogleCloudPlatform/terraform-google-managed-instance-group) for convenience.