### PR TITLE
Update to Vault 0.10.x and Consul 1.2.x. Fix helper script commands accordingly. 

### DIFF
--- a/examples/vault-cluster-public/README.md
+++ b/examples/vault-cluster-public/README.md
@@ -33,7 +33,8 @@ To deploy a Vault Cluster:
 1. Install [Terraform](https://www.terraform.io/).
 1. Make sure your local environment is authenticated to Google Cloud.
 1. Open `variables.tf` and fill in any variables that don't have a default, including putting your Goolge Image ID into
-   the `vault_source_image` and `consul_server_source_image` variables.
+   the `vault_source_image` and `consul_server_source_image` variables. Alternatively, initialize the variables by creating
+   a `terraform.tfvars` file.
 1. Run `terraform init`.
 1. Run `terraform plan`.
 1. If the plan looks good, run `terraform apply`.

--- a/examples/vault-consul-image/README.md
+++ b/examples/vault-consul-image/README.md
@@ -29,18 +29,18 @@ To build the Vault and Consul Google Image:
 
 1. Configure your environment's Google credentials using the [Google Cloud SDK](https://cloud.google.com/sdk/).
 
-1. Update the `variables` section of the `vault-consul.json` Packer template to configure the Project ID, Google Cloud Zone, 
-   and Consul and Vault versions you wish to use.
-   
-1. Use the [private-tls-cert module](https://github.com/hashicorp/terraform-google-vault/tree/master/modules/private-tls-cert) to generate a CA cert and public and private keys for a 
-   TLS cert: 
-   
+1. Use the [private-tls-cert module](https://github.com/hashicorp/terraform-google-vault/tree/master/modules/private-tls-cert) to generate a CA cert and public and private keys for a
+   TLS cert:
+
     1. Set the `dns_names` parameter to `vault.service.consul`. If you're using the [vault-cluster-public
-       example](https://github.com/hashicorp/terraform-google-vault/tree/master/examples/vault-cluster-public) and want a public domain name (e.g. `vault.example.com`), add that 
+       example](https://github.com/hashicorp/terraform-google-vault/tree/master/examples/vault-cluster-public) and want a public domain name (e.g. `vault.example.com`), add that
        domain name here too.
-    1. Set the `ip_addresses` to `127.0.0.1`. 
-    1. For production usage, you should take care to protect the private key by encrypting it (see [Using TLS 
-       certs](https://github.com/hashicorp/terraform-google-vault/tree/master/modules/private-tls-cert#using-tls-certs) for more info).  
+    1. Set the `ip_addresses` to `127.0.0.1`.
+    1. For production usage, you should take care to protect the private key by encrypting it (see [Using TLS
+       certs](https://github.com/hashicorp/terraform-google-vault/tree/master/modules/private-tls-cert#using-tls-certs) for more info).
+
+1. Update the `variables` section of the `vault-consul.json` Packer template to configure the Project ID, Google Cloud Zone,
+   and Consul and Vault versions you wish to use. Alternatively, you can pass in these values using `packer build vault-consul.json -var var_name=var_value ...`
 
 1. Run `packer build vault-consul.json`.
 

--- a/examples/vault-consul-image/vault-consul.json
+++ b/examples/vault-consul-image/vault-consul.json
@@ -3,9 +3,9 @@
   "variables": {
     "project_id": null,
     "zone": null,
-    "vault_version": "0.8.3",
+    "vault_version": "0.10.4",
     "consul_module_version": "v0.0.3",
-    "consul_version": "1.0.0",
+    "consul_version": "1.2.2",
     "ca_public_key_path": null,
     "tls_public_key_path": null,
     "tls_private_key_path": null

--- a/examples/vault-examples-helper/vault-examples-helper.sh
+++ b/examples/vault-examples-helper/vault-examples-helper.sh
@@ -215,17 +215,17 @@ function print_instructions {
 
   instructions+=("To initialize your Vault cluster, SSH to one of the servers and run the init command:\n")
   instructions+=("    gcloud compute --project \"$project\" ssh --zone \"$zone\" $server_name")
-  instructions+=("    vault init")
+  instructions+=("    vault operator init")
 
   instructions+=("\nTo unseal your Vault cluster, SSH to each of the servers and run the unseal command with 3 of the 5 unseal keys:\n")
   for server_name in "${server_names[@]}"; do
     instructions+=("    gcloud compute --project \"$project\" ssh --zone \"$zone\" $server_name")
-    instructions+=("    vault unseal (run this 3 times)\n")
+    instructions+=("    vault operator unseal (run this 3 times)\n")
   done
 
   instructions+=("\nOnce your cluster is unsealed, you can read and write secrets by SSHing to any of the servers:\n")
   instructions+=("    gcloud compute --project \"$project\" ssh --zone \"$zone\" $server_name")
-  instructions+=("    vault auth")
+  instructions+=("    vault login")
   instructions+=("    vault write secret/example value=secret")
   instructions+=("    vault read secret/example")
 

--- a/examples/vault-examples-helper/vault-examples-helper.sh
+++ b/examples/vault-examples-helper/vault-examples-helper.sh
@@ -56,7 +56,7 @@ function get_required_terraform_output {
   output_value=$(get_optional_terraform_output "$output_name")
 
   if [[ -z "$output_value" ]]; then
-    log_error "Unable to find a value for Terraform output $output_name"
+    log_error "Unable to find a value for Terraform output $output_name. Are you running this script in the same directory as your Terraform configuration?"
     exit 1
   fi
 
@@ -107,6 +107,11 @@ function get_all_vault_server_property_values {
       return
     else
       log_warn "Found $server_property_name for ${#vals[@]} of $expected_num_vault_servers Vault servers. Will sleep for $SLEEP_BETWEEN_RETRIES_SEC seconds and try again."
+
+      if [[ "${#vals[@]}" == 0 ]]; then
+        log_warn "Is the Terraform variable \"assign_public_ip_addresses\" of the vault-cluster Terraform module set to \"true\"?"
+      fi
+
       sleep "$SLEEP_BETWEEN_RETRIES_SEC"
     fi
   done

--- a/modules/vault-cluster/outputs.tf
+++ b/modules/vault-cluster/outputs.tf
@@ -23,11 +23,11 @@ output "firewall_rule_allow_intracluster_vault_id" {
 }
 
 output "firewall_rule_allow_inbound_api_url" {
-  value = "${google_compute_firewall.allow_inbound_api.self_link}"
+  value = "${google_compute_firewall.allow_inbound_api.*.self_link}"
 }
 
 output "firewall_rule_allow_inbound_api_id" {
-  value = "${google_compute_firewall.allow_inbound_api.id}"
+  value = "${google_compute_firewall.allow_inbound_api.*.id}"
 }
 
 output "firewall_rule_allow_inbound_health_check_url" {


### PR DESCRIPTION
This PR updates to the latest versions of Vault (0.10.4) and Consul (1.2.2), makes some minor clarification to docs, and updates the helper script to use the now current versions of vault commands (e.g. replacing `vault auth` with `vault login`).

It also fixes an issue where the following warning was shown on every `terraform apply` and `terraform destroy`:

```
Warning: output "firewall_rule_allow_inbound_api_url": must use splat syntax to access
 google_compute_firewall.allow_inbound_api attribute "self_link", because it has "count" set; use
 google_compute_firewall.allow_inbound_api.*.self_link to obtain a list of the attributes across all
 instances
```