### PR TITLE
Add subnetwork_name variable to vault_cluster module

### DIFF
--- a/modules/vault-cluster/main.tf
+++ b/modules/vault-cluster/main.tf
@@ -65,6 +65,7 @@ resource "google_compute_instance_template" "vault_public" {
 
   network_interface {
     network = "${var.network_name}"
+    subnetwork = "${var.subnetwork_name}"
     access_config {
       # The presence of this property assigns a public IP address to each Compute Instance. We intentionally leave it
       # blank so that an external IP address is selected automatically.

--- a/modules/vault-cluster/main.tf
+++ b/modules/vault-cluster/main.tf
@@ -64,8 +64,8 @@ resource "google_compute_instance_template" "vault_public" {
   }
 
   network_interface {
-    network = "${var.network_name}"
-    subnetwork = "${var.subnetwork_name}"
+    network = "${var.subnetwork_name != "" ? "" : var.network_name}"
+    subnetwork = "${var.subnetwork_name != "" ? var.subnetwork_name : ""}"
     access_config {
       # The presence of this property assigns a public IP address to each Compute Instance. We intentionally leave it
       # blank so that an external IP address is selected automatically.

--- a/modules/vault-cluster/variables.tf
+++ b/modules/vault-cluster/variables.tf
@@ -69,6 +69,11 @@ variable "network_name" {
   default = "default"
 }
 
+variable "subnetwork_name" {
+  description = "The name of the VPC Subnetwork where all resources should be created. Defaults to the default subnetwork for the network and region."
+  default = ""
+}
+
 variable "custom_tags" {
   description = "A list of tags that will be added to the Compute Instance Template in addition to the tags automatically added by this module."
   type = "list"


### PR DESCRIPTION
Related Issue: https://github.com/hashicorp/terraform-google-vault/issues/22

Add `subnetwork_name` variable to allow the use of non-default subnets, or subnets with custom names.

This change fixes a bug present when a subnet named `default` does not exist, or some other reason meaning a different subnet needs to be used:
```
* module.vault_cluster.google_compute_instance_template.vault_public: 1 error(s) occurred:

* google_compute_instance_template.vault_public: Error creating instance template: googleapi: Error 400: Invalid value for field 'resource.properties.networkInterfaces[0].subnetwork': ''. Network interface must specify a subnet if the network resource is in custom subnet mode., invalid
```