### PR TITLE
Switch from Zonal Managed Instance Group to Regional Managed Instance Group

### DIFF
--- a/examples/root-example/startup-script-vault.sh
+++ b/examples/root-example/startup-script-vault.sh
@@ -16,4 +16,4 @@ readonly VAULT_TLS_KEY_FILE="/opt/vault/tls/vault.key.pem"
 
 # Note that any variables below with <dollar-sign><curly-brace><var-name><curly-brace> are expected to be interpolated by Terraform.
 /opt/consul/bin/run-consul --client --cluster-tag-name "${consul_cluster_tag_name}"
-/opt/vault/bin/run-vault --gcs-bucket ${vault_cluster_tag_name} --tls-cert-file "$VAULT_TLS_CERT_FILE"  --tls-key-file "$VAULT_TLS_KEY_FILE"
+/opt/vault/bin/run-vault --gcs-bucket ${vault_cluster_tag_name} --tls-cert-file "$VAULT_TLS_CERT_FILE"  --tls-key-file "$VAULT_TLS_KEY_FILE" ${enable_vault_ui}

--- a/examples/vault-cluster-private/main.tf
+++ b/examples/vault-cluster-private/main.tf
@@ -26,7 +26,7 @@ module "vault_cluster" {
   # source = "git::git@github.com:hashicorp/terraform-google-vault.git//modules/vault-cluster?ref=v0.0.1"
   source = "../../modules/vault-cluster"
 
-  gcp_zone = "${var.gcp_zone}"
+  gcp_region = "${var.gcp_region}"
 
   cluster_name = "${var.vault_cluster_name}"
   cluster_size = "${var.vault_cluster_size}"
@@ -69,9 +69,10 @@ data "template_file" "startup_script_vault" {
 # ---------------------------------------------------------------------------------------------------------------------
 
 module "consul_cluster" {
-  source = "git::git@github.com:hashicorp/terraform-google-consul.git//modules/consul-cluster?ref=v0.0.3"
+  source = "git::git@github.com:hashicorp/terraform-google-consul.git//modules/consul-cluster?ref=v0.2.0"
 
-  gcp_zone = "${var.gcp_zone}"
+  gcp_region = "${var.gcp_region}"
+
   cluster_name = "${var.consul_server_cluster_name}"
   cluster_tag_name = "${var.consul_server_cluster_name}"
   cluster_size = "${var.consul_server_cluster_size}"

--- a/examples/vault-cluster-private/main.tf
+++ b/examples/vault-cluster-private/main.tf
@@ -60,6 +60,7 @@ data "template_file" "startup_script_vault" {
   vars {
     consul_cluster_tag_name = "${var.consul_server_cluster_name}"
     vault_cluster_tag_name = "${var.vault_cluster_name}"
+    enable_vault_ui = "${var.enable_vault_ui ? "--enable-vault-ui" : ""}"
   }
 }
 

--- a/examples/vault-cluster-private/outputs.tf
+++ b/examples/vault-cluster-private/outputs.tf
@@ -2,8 +2,8 @@ output "gcp_project" {
   value = "${var.gcp_project}"
 }
 
-output "gcp_zone" {
-  value = "${var.gcp_zone}"
+output "gcp_region" {
+  value = "${var.gcp_region}"
 }
 
 output "vault_cluster_size" {

--- a/examples/vault-cluster-private/startup-script-vault.sh
+++ b/examples/vault-cluster-private/startup-script-vault.sh
@@ -16,4 +16,4 @@ readonly VAULT_TLS_KEY_FILE="/opt/vault/tls/vault.key.pem"
 
 # Note that any variables below with <dollar-sign><curly-brace><var-name><curly-brace> are expected to be interpolated by Terraform.
 /opt/consul/bin/run-consul --client --cluster-tag-name "${consul_cluster_tag_name}"
-/opt/vault/bin/run-vault --gcs-bucket ${vault_cluster_tag_name} --tls-cert-file "$VAULT_TLS_CERT_FILE"  --tls-key-file "$VAULT_TLS_KEY_FILE"
+/opt/vault/bin/run-vault --gcs-bucket ${vault_cluster_tag_name} --tls-cert-file "$VAULT_TLS_CERT_FILE" --tls-key-file "$VAULT_TLS_KEY_FILE" ${enable_vault_ui}

--- a/examples/vault-cluster-private/variables.tf
+++ b/examples/vault-cluster-private/variables.tf
@@ -8,11 +8,7 @@ variable "gcp_project" {
 }
 
 variable "gcp_region" {
-  description = "The region in which all GCP resources will be launched."
-}
-
-variable "gcp_zone" {
-  description = "The region in which all GCP resources will be launched."
+  description = "The Region in which all GCP resources will be launched."
 }
 
 variable "vault_cluster_name" {

--- a/examples/vault-cluster-private/variables.tf
+++ b/examples/vault-cluster-private/variables.tf
@@ -74,3 +74,8 @@ variable "root_volume_disk_type" {
   description = "The GCE disk type. Can be either pd-ssd, local-ssd, or pd-standard"
   default = "pd-standard"
 }
+
+variable "enable_vault_ui" {
+  description = "If true, enable the Vault UI"
+  default = true
+}

--- a/examples/vault-cluster-public/main.tf
+++ b/examples/vault-cluster-public/main.tf
@@ -25,7 +25,7 @@ module "vault_cluster" {
   # source = "git::git@github.com:hashicorp/terraform-google-vault.git//modules/vault-cluster?ref=v0.0.1"
   source = "../../modules/vault-cluster"
 
-  gcp_zone = "${var.gcp_zone}"
+  gcp_region = "${var.gcp_region}"
 
   cluster_name = "${var.vault_cluster_name}"
   cluster_size = "${var.vault_cluster_size}"
@@ -96,9 +96,10 @@ module "vault_load_balancer" {
 # ---------------------------------------------------------------------------------------------------------------------
 
 module "consul_cluster" {
-  source = "git::git@github.com:hashicorp/terraform-google-consul.git//modules/consul-cluster?ref=v0.0.3"
+  source = "git::git@github.com:hashicorp/terraform-google-consul.git//modules/consul-cluster?ref=v0.2.0"
 
-  gcp_zone = "${var.gcp_zone}"
+  gcp_region = "${var.gcp_region}"
+
   cluster_name = "${var.consul_server_cluster_name}"
   cluster_tag_name = "${var.consul_server_cluster_name}"
   cluster_size = "${var.consul_server_cluster_size}"

--- a/examples/vault-cluster-public/main.tf
+++ b/examples/vault-cluster-public/main.tf
@@ -71,6 +71,7 @@ data "template_file" "startup_script_vault" {
     consul_cluster_tag_name = "${var.consul_server_cluster_name}"
     vault_cluster_tag_name = "${var.vault_cluster_name}"
     web_proxy_port = "${var.web_proxy_port}"
+    enable_vault_ui = "${var.enable_vault_ui ? "--enable-vault-ui" : ""}"
   }
 }
 

--- a/examples/vault-cluster-public/outputs.tf
+++ b/examples/vault-cluster-public/outputs.tf
@@ -2,8 +2,8 @@ output "gcp_project" {
   value = "${var.gcp_project}"
 }
 
-output "gcp_zone" {
-  value = "${var.gcp_zone}"
+output "gcp_region" {
+  value = "${var.gcp_region}"
 }
 
 output "vault_cluster_size" {

--- a/examples/vault-cluster-public/startup-script-vault.sh
+++ b/examples/vault-cluster-public/startup-script-vault.sh
@@ -16,7 +16,7 @@ readonly VAULT_TLS_KEY_FILE="/opt/vault/tls/vault.key.pem"
 
 # Note that any variables below with <dollar-sign><curly-brace><var-name><curly-brace> are expected to be interpolated by Terraform.
 /opt/consul/bin/run-consul --client --cluster-tag-name "${consul_cluster_tag_name}"
-/opt/vault/bin/run-vault --gcs-bucket ${vault_cluster_tag_name} --tls-cert-file "$VAULT_TLS_CERT_FILE"  --tls-key-file "$VAULT_TLS_KEY_FILE"
+/opt/vault/bin/run-vault --gcs-bucket ${vault_cluster_tag_name} --tls-cert-file "$VAULT_TLS_CERT_FILE" --tls-key-file "$VAULT_TLS_KEY_FILE" ${enable_vault_ui}
 
 # We run an nginx server to expose an HTTP endpoint that will be used solely for Vault health checks. This is because
 # Google Cloud only permits HTTP health checks to be associated with the Load Balancer.

--- a/examples/vault-cluster-public/variables.tf
+++ b/examples/vault-cluster-public/variables.tf
@@ -79,3 +79,8 @@ variable "root_volume_disk_type" {
   description = "The GCE disk type. Can be either pd-ssd, local-ssd, or pd-standard"
   default = "pd-standard"
 }
+
+variable "enable_vault_ui" {
+  description = "If true, enable the Vault UI"
+  default = true
+}

--- a/examples/vault-cluster-public/variables.tf
+++ b/examples/vault-cluster-public/variables.tf
@@ -11,10 +11,6 @@ variable "gcp_region" {
   description = "The region in which all GCP resources will be launched."
 }
 
-variable "gcp_zone" {
-  description = "The region in which all GCP resources will be launched."
-}
-
 variable "vault_cluster_name" {
   description = "The name of the Consul Server cluster. All resources will be namespaced by this value. E.g. consul-server-prod"
 }

--- a/examples/vault-consul-image/vault-consul.json
+++ b/examples/vault-consul-image/vault-consul.json
@@ -3,8 +3,8 @@
   "variables": {
     "project_id": null,
     "zone": null,
-    "vault_version": "0.10.4",
-    "consul_module_version": "v0.0.3",
+    "vault_version": "0.11.1",
+    "consul_module_version": "v0.2.0",
     "consul_version": "1.2.2",
     "ca_public_key_path": null,
     "tls_public_key_path": null,

--- a/main.tf
+++ b/main.tf
@@ -26,8 +26,7 @@ module "vault_cluster" {
 
   gcp_project_id     = "${var.gcp_project_id}"
   network_project_id = "${var.network_project_id}"
-
-  gcp_zone = "${var.gcp_zone}"
+  gcp_region         = "${var.gcp_region}"
 
   cluster_name     = "${var.vault_cluster_name}"
   cluster_size     = "${var.vault_cluster_size}"
@@ -76,6 +75,7 @@ module "consul_cluster" {
 
   gcp_project_id     = "${var.gcp_project_id}"
   gcp_region         = "${var.gcp_region}"
+
   cluster_name       = "${var.consul_server_cluster_name}"
   cluster_tag_name   = "${var.consul_server_cluster_name}"
   cluster_size       = "${var.consul_server_cluster_size}"

--- a/main.tf
+++ b/main.tf
@@ -62,7 +62,9 @@ data "template_file" "startup_script_vault" {
 
   vars {
     consul_cluster_tag_name = "${var.consul_server_cluster_name}"
-    vault_cluster_tag_name  = "${var.vault_cluster_name}"
+    vault_cluster_tag_name = "${var.vault_cluster_name}"
+
+    enable_vault_ui = "${var.enable_vault_ui ? "--enable-vault-ui" : ""}"
   }
 }
 

--- a/modules/install-vault/install-vault
+++ b/modules/install-vault/install-vault
@@ -100,7 +100,9 @@ function install_dependencies {
 
   if $(has_apt_get); then
     sudo apt-get update -y
-    sudo apt-get install -y curl unzip jq
+
+    # libcap2-bin: Installs setcap, which we will use to call configure_mlock
+    sudo apt-get install -y curl unzip jq libcap2-bin
     install_supervisord_debian
   else
     log_error "Could not find apt-get. Cannot install dependencies on this OS."

--- a/modules/run-vault/run-vault
+++ b/modules/run-vault/run-vault
@@ -41,6 +41,7 @@ function print_usage {
   echo -e "  --log-level\t\tThe log verbosity to use with Vault. Default is $DEFAULT_LOG_LEVEL."
   echo -e "  --user\t\tThe user to run Vault as. Default is to use the owner of --config-dir."
   echo -e "  --skip-vault-config\tIf this flag is set, don't generate a Vault configuration file. Default is false."
+  echo -e "  --enable-ui\tIf this flag is set, the Vault UI will be enabled. Default is false."
 
   echo
   echo "Example:"
@@ -128,6 +129,8 @@ function generate_vault_config {
   local readonly user="$6"
   local readonly gcs_bucket="$7"
   local readonly gcp_creds_file="$8"
+  local readonly enable_ui="$9"
+
   local readonly config_path="$config_dir/$VAULT_CONFIG_FILE"
 
   local instance_ip_address
@@ -135,6 +138,8 @@ function generate_vault_config {
 
   log_info "Creating default Vault config file in $config_path"
   cat > "$config_path" <<EOF
+ui = $enable_ui
+
 storage "gcs" {
   bucket = "$gcs_bucket"
   credentials_file = "$gcp_creds_file"
@@ -208,6 +213,7 @@ function run {
   local log_level="$DEFAULT_LOG_LEVEL"
   local user=""
   local skip_vault_config="false"
+  local enable_ui="false"
   local all_args=()
 
   while [[ $# > 0 ]]; do
@@ -261,6 +267,9 @@ function run {
       --skip-vault-config)
         skip_vault_config="true"
         ;;
+      --enable-ui)
+        enable_ui="true"
+        ;;
       --help)
         print_usage
         exit
@@ -305,7 +314,7 @@ function run {
   if [[ "$skip_vault_config" == "true" ]]; then
     log_info "The --skip-vault-config flag is set, so will not generate a default Vault config file."
   else
-    generate_vault_config "$tls_cert_file" "$tls_key_file" "$port" "$cluster_port" "$config_dir" "$user" "$gcs_bucket" "$gcp_creds_file"
+    generate_vault_config "$tls_cert_file" "$tls_key_file" "$port" "$cluster_port" "$config_dir" "$user" "$gcs_bucket" "$gcp_creds_file" "$enable_ui"
   fi
 
   generate_supervisor_config "$SUPERVISOR_CONFIG_PATH" "$config_dir" "$bin_dir" "$log_dir" "$log_level" "$user"

--- a/modules/vault-cluster/main.tf
+++ b/modules/vault-cluster/main.tf
@@ -16,14 +16,14 @@ terraform {
 # ---------------------------------------------------------------------------------------------------------------------
 
 # Create the single-zone Managed Instance Group where Vault will run.
-resource "google_compute_instance_group_manager" "vault" {
+resource "google_compute_region_instance_group_manager" "vault" {
   name = "${var.cluster_name}-ig"
 
   project = "${var.gcp_project_id}"
 
   base_instance_name = "${var.cluster_name}"
   instance_template  = "${data.template_file.compute_instance_template_self_link.rendered}"
-  zone               = "${var.gcp_zone}"
+  region             = "${var.gcp_region}"
 
   # Restarting a Vault server has an important consequence: The Vault server has to be manually unsealed again. Therefore,
   # the update strategy used to roll out a new GCE Instance Template must be a rolling update. But since Terraform does

--- a/modules/vault-cluster/outputs.tf
+++ b/modules/vault-cluster/outputs.tf
@@ -3,11 +3,11 @@ output "cluster_tag_name" {
 }
 
 output "instance_group_id" {
-  value = "${google_compute_instance_group_manager.vault.id}"
+  value = "${google_compute_region_instance_group_manager.vault.id}"
 }
 
 output "instance_group_url" {
-  value = "${google_compute_instance_group_manager.vault.self_link}"
+  value = "${google_compute_region_instance_group_manager.vault.self_link}"
 }
 
 output "instance_template_url" {

--- a/modules/vault-cluster/variables.tf
+++ b/modules/vault-cluster/variables.tf
@@ -3,8 +3,8 @@
 # You must provide a value for each of these parameters.
 # ---------------------------------------------------------------------------------------------------------------------
 
-variable "gcp_zone" {
-  description = "All GCP resources will be launched in this Zone."
+variable "gcp_region" {
+  description = "All GCP resources will be launched in this Region."
 }
 
 variable "gcp_project_id" {

--- a/variables.tf
+++ b/variables.tf
@@ -11,10 +11,6 @@ variable "gcp_region" {
   description = "The region in which all GCP resources will be launched."
 }
 
-variable "gcp_zone" {
-  description = "The region in which all GCP resources will be launched."
-}
-
 variable "vault_cluster_name" {
   description = "The name of the Consul Server cluster. All resources will be namespaced by this value. E.g. consul-server-prod"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -84,5 +84,10 @@ variable "root_volume_disk_size_gb" {
 
 variable "root_volume_disk_type" {
   description = "The GCE disk type. Can be either pd-ssd, local-ssd, or pd-standard"
-  default     = "pd-standard"
+  default = "pd-standard"
+}
+
+variable "enable_vault_ui" {
+  description = "If true, enable the Vault UI"
+  default = true
 }


### PR DESCRIPTION
This PR:

- Replaces the Zonal Managed Instance Group with a Regional Managed Instance Group. This way, Vault nodes are spread across multiple Zones instead of being co-located in a single Zone, which meant no High Availability.

- Makes sure any local libraries needed to run `setcap` are installed. This is used to enable mlock settings for Vault.

- Enable the Vault UI by default on examples.