### PR TITLE
Set project variable to allow for multi-project deployments

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -21,7 +21,7 @@ terraform {
 module "vault_cluster" {
   # When using these modules in your own templates, you will need to use a Git URL with a ref attribute that pins you
   # to a specific version of the modules, such as the following example:
-  # source = "./modules/vault-cluster?ref=cloudbuy-test"
+  # source = "git::git@github.com:hashicorp/terraform-google-vault.git//modules/vault-cluster?ref=v0.0.1"
   source = "modules/vault-cluster"
 
   gcp_project_id     = "${var.gcp_project_id}"
@@ -72,10 +72,9 @@ data "template_file" "startup_script_vault" {
 # ---------------------------------------------------------------------------------------------------------------------
 
 module "consul_cluster" {
-  source = "git::https://gitlab.office.ukplc.corp/infrastructure/terraform-modules/terraform-google-consul//modules/consul-cluster?ref=cloudbuy-test"
+  source = "git::git@github.com:hashicorp/terraform-google-consul.git//modules/consul-cluster?ref=v0.3.0"
 
   gcp_project_id     = "${var.gcp_project_id}"
-  network_project_id = "${var.network_project_id}"
   gcp_region         = "${var.gcp_region}"
   cluster_name       = "${var.consul_server_cluster_name}"
   cluster_tag_name   = "${var.consul_server_cluster_name}"

--- a/main.tf
+++ b/main.tf
@@ -24,7 +24,7 @@ module "vault_cluster" {
   # source = "git::git@github.com:hashicorp/terraform-google-vault.git//modules/vault-cluster?ref=v0.0.1"
   source = "modules/vault-cluster"
 
-  project = "${var.gcp_project}"
+  gcp_project_id = "${var.gcp_project_id}"
 
   gcp_zone = "${var.gcp_zone}"
 
@@ -73,7 +73,7 @@ data "template_file" "startup_script_vault" {
 module "consul_cluster" {
   source = "git::git@github.com:hashicorp/terraform-google-consul.git//modules/consul-cluster?ref=v0.0.3"
 
-  gcp_project_id   = "${var.gcp_project}"
+  gcp_project_id   = "${var.gcp_project_id}"
   gcp_zone         = "${var.gcp_zone}"
   cluster_name     = "${var.consul_server_cluster_name}"
   cluster_tag_name = "${var.consul_server_cluster_name}"

--- a/main.tf
+++ b/main.tf
@@ -76,7 +76,7 @@ module "consul_cluster" {
 
   gcp_project_id     = "${var.gcp_project_id}"
   network_project_id = "${var.network_project_id}"
-  gcp_zone           = "${var.gcp_zone}"
+  gcp_region         = "${var.gcp_region}"
   cluster_name       = "${var.consul_server_cluster_name}"
   cluster_tag_name   = "${var.consul_server_cluster_name}"
   cluster_size       = "${var.consul_server_cluster_size}"

--- a/main.tf
+++ b/main.tf
@@ -7,8 +7,7 @@
 # ---------------------------------------------------------------------------------------------------------------------
 
 provider "google" {
-  project     = "${var.gcp_project}"
-  region      = "${var.gcp_region}"
+  region = "${var.gcp_region}"
 }
 
 terraform {
@@ -25,23 +24,25 @@ module "vault_cluster" {
   # source = "git::git@github.com:hashicorp/terraform-google-vault.git//modules/vault-cluster?ref=v0.0.1"
   source = "modules/vault-cluster"
 
+  project = "${var.gcp_project}"
+
   gcp_zone = "${var.gcp_zone}"
 
-  cluster_name = "${var.vault_cluster_name}"
-  cluster_size = "${var.vault_cluster_size}"
+  cluster_name     = "${var.vault_cluster_name}"
+  cluster_size     = "${var.vault_cluster_size}"
   cluster_tag_name = "${var.vault_cluster_name}"
-  machine_type = "${var.vault_cluster_machine_type}"
+  machine_type     = "${var.vault_cluster_machine_type}"
 
-  source_image = "${var.vault_source_image}"
+  source_image   = "${var.vault_source_image}"
   startup_script = "${data.template_file.startup_script_vault.rendered}"
 
-  gcs_bucket_name = "${var.vault_cluster_name}"
-  gcs_bucket_location = "${var.gcs_bucket_location}"
+  gcs_bucket_name          = "${var.vault_cluster_name}"
+  gcs_bucket_location      = "${var.gcs_bucket_location}"
   gcs_bucket_storage_class = "${var.gcs_bucket_class}"
   gcs_bucket_force_destroy = "${var.gcs_bucket_force_destroy}"
 
   root_volume_disk_size_gb = "${var.root_volume_disk_size_gb}"
-  root_volume_disk_type = "${var.root_volume_disk_type}"
+  root_volume_disk_type    = "${var.root_volume_disk_type}"
 
   # Even when the Vault cluster is pubicly accessible via a Load Balancer, we still make the Vault nodes themselves
   # private to improve the overall security posture. Note that the only way to reach private nodes via SSH is to first
@@ -51,6 +52,7 @@ module "vault_cluster" {
   # To enable external access to the Vault Cluster, enter the approved CIDR Blocks or tags below.
   # We enable health checks from the Consul Server cluster to Vault.
   allowed_inbound_cidr_blocks_api = ["0.0.0.0/0"]
+
   allowed_inbound_tags_api = ["${var.consul_server_cluster_name}"]
 }
 
@@ -60,7 +62,7 @@ data "template_file" "startup_script_vault" {
 
   vars {
     consul_cluster_tag_name = "${var.consul_server_cluster_name}"
-    vault_cluster_tag_name = "${var.vault_cluster_name}"
+    vault_cluster_tag_name  = "${var.vault_cluster_name}"
   }
 }
 
@@ -71,10 +73,11 @@ data "template_file" "startup_script_vault" {
 module "consul_cluster" {
   source = "git::git@github.com:hashicorp/terraform-google-consul.git//modules/consul-cluster?ref=v0.0.3"
 
-  gcp_zone = "${var.gcp_zone}"
-  cluster_name = "${var.consul_server_cluster_name}"
+  gcp_project_id   = "${var.gcp_project}"
+  gcp_zone         = "${var.gcp_zone}"
+  cluster_name     = "${var.consul_server_cluster_name}"
   cluster_tag_name = "${var.consul_server_cluster_name}"
-  cluster_size = "${var.consul_server_cluster_size}"
+  cluster_size     = "${var.consul_server_cluster_size}"
 
   source_image = "${var.consul_server_source_image}"
   machine_type = "${var.consul_server_machine_type}"
@@ -85,7 +88,7 @@ module "consul_cluster" {
   # Note that the only way to reach private nodes via SSH is to first SSH into another node that is not private.
   assign_public_ip_addresses = true
 
-  allowed_inbound_tags_dns = ["${var.vault_cluster_name}"]
+  allowed_inbound_tags_dns      = ["${var.vault_cluster_name}"]
   allowed_inbound_tags_http_api = ["${var.vault_cluster_name}"]
 }
 
@@ -94,6 +97,6 @@ data "template_file" "startup_script_consul" {
   template = "${file("${path.module}/examples/root-example/startup-script-consul.sh")}"
 
   vars {
-    cluster_tag_name   = "${var.consul_server_cluster_name}"
+    cluster_tag_name = "${var.consul_server_cluster_name}"
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -25,6 +25,7 @@ module "vault_cluster" {
   source = "modules/vault-cluster"
 
   gcp_project_id = "${var.gcp_project_id}"
+  network_project_id = "${var.network_project_id}"
 
   gcp_zone = "${var.gcp_zone}"
 
@@ -74,6 +75,7 @@ module "consul_cluster" {
   source = "git::git@github.com:hashicorp/terraform-google-consul.git//modules/consul-cluster?ref=v0.0.3"
 
   gcp_project_id   = "${var.gcp_project_id}"
+  network_project_id = "${var.network_project_id}"
   gcp_zone         = "${var.gcp_zone}"
   cluster_name     = "${var.consul_server_cluster_name}"
   cluster_tag_name = "${var.consul_server_cluster_name}"

--- a/main.tf
+++ b/main.tf
@@ -21,7 +21,7 @@ terraform {
 module "vault_cluster" {
   # When using these modules in your own templates, you will need to use a Git URL with a ref attribute that pins you
   # to a specific version of the modules, such as the following example:
-  # source = "git::git@github.com:hashicorp/terraform-google-vault.git//modules/vault-cluster?ref=v0.0.1"
+  # source = "./modules/vault-cluster?ref=cloudbuy-test"
   source = "modules/vault-cluster"
 
   gcp_project_id     = "${var.gcp_project_id}"
@@ -72,7 +72,7 @@ data "template_file" "startup_script_vault" {
 # ---------------------------------------------------------------------------------------------------------------------
 
 module "consul_cluster" {
-  source = "git::git@github.com:hashicorp/terraform-google-consul.git//modules/consul-cluster?ref=v0.0.3"
+  source = "git::https://gitlab.office.ukplc.corp/infrastructure/terraform-modules/terraform-google-consul//modules/consul-cluster?ref=cloudbuy-test"
 
   gcp_project_id     = "${var.gcp_project_id}"
   network_project_id = "${var.network_project_id}"

--- a/main.tf
+++ b/main.tf
@@ -24,7 +24,7 @@ module "vault_cluster" {
   # source = "git::git@github.com:hashicorp/terraform-google-vault.git//modules/vault-cluster?ref=v0.0.1"
   source = "modules/vault-cluster"
 
-  gcp_project_id = "${var.gcp_project_id}"
+  gcp_project_id     = "${var.gcp_project_id}"
   network_project_id = "${var.network_project_id}"
 
   gcp_zone = "${var.gcp_zone}"
@@ -74,12 +74,12 @@ data "template_file" "startup_script_vault" {
 module "consul_cluster" {
   source = "git::git@github.com:hashicorp/terraform-google-consul.git//modules/consul-cluster?ref=v0.0.3"
 
-  gcp_project_id   = "${var.gcp_project_id}"
+  gcp_project_id     = "${var.gcp_project_id}"
   network_project_id = "${var.network_project_id}"
-  gcp_zone         = "${var.gcp_zone}"
-  cluster_name     = "${var.consul_server_cluster_name}"
-  cluster_tag_name = "${var.consul_server_cluster_name}"
-  cluster_size     = "${var.consul_server_cluster_size}"
+  gcp_zone           = "${var.gcp_zone}"
+  cluster_name       = "${var.consul_server_cluster_name}"
+  cluster_tag_name   = "${var.consul_server_cluster_name}"
+  cluster_size       = "${var.consul_server_cluster_size}"
 
   source_image = "${var.consul_server_source_image}"
   machine_type = "${var.consul_server_machine_type}"

--- a/modules/vault-cluster/main.tf
+++ b/modules/vault-cluster/main.tf
@@ -166,7 +166,7 @@ resource "google_compute_instance_template" "vault_private" {
 resource "google_compute_firewall" "allow_intracluster_vault" {
   name    = "${var.cluster_name}-rule-cluster"
   network = "${var.network_name}"
-  project = "${var.gcp_project_id}"
+  project = "${var.network_project_id}"
 
   allow {
     protocol = "tcp"
@@ -190,7 +190,7 @@ resource "google_compute_firewall" "allow_inbound_api" {
 
   name    = "${var.cluster_name}-rule-external-api-access"
   network = "${var.network_name}"
-  project = "${var.gcp_project_id}"
+  project = "${var.network_project_id}"
 
   allow {
     protocol = "tcp"

--- a/modules/vault-cluster/main.tf
+++ b/modules/vault-cluster/main.tf
@@ -67,7 +67,8 @@ resource "google_compute_instance_template" "vault_public" {
   }
 
   network_interface {
-    network = "${var.network_name}"
+    network    = "${var.subnetwork_name != "" ? "" : var.network_name}"
+    subnetwork = "${var.subnetwork_name != "" ? var.subnetwork_name : ""}"
 
     access_config {
       # The presence of this property assigns a public IP address to each Compute Instance. We intentionally leave it
@@ -129,7 +130,8 @@ resource "google_compute_instance_template" "vault_private" {
   }
 
   network_interface {
-    network = "${var.network_name}"
+    network    = "${var.subnetwork_name != "" ? "" : var.network_name}"
+    subnetwork = "${var.subnetwork_name != "" ? var.subnetwork_name : ""}"
   }
 
   # For a full list of oAuth 2.0 Scopes, see https://developers.google.com/identity/protocols/googlescopes

--- a/modules/vault-cluster/main.tf
+++ b/modules/vault-cluster/main.tf
@@ -67,8 +67,9 @@ resource "google_compute_instance_template" "vault_public" {
   }
 
   network_interface {
-    network    = "${var.subnetwork_name != "" ? "" : var.network_name}"
-    subnetwork = "${var.subnetwork_name != "" ? var.subnetwork_name : ""}"
+    network            = "${var.subnetwork_name != "" ? "" : var.network_name}"
+    subnetwork         = "${var.subnetwork_name != "" ? var.subnetwork_name : ""}"
+    subnetwork_project = "${var.network_project_id}"
 
     access_config {
       # The presence of this property assigns a public IP address to each Compute Instance. We intentionally leave it
@@ -130,8 +131,9 @@ resource "google_compute_instance_template" "vault_private" {
   }
 
   network_interface {
-    network    = "${var.subnetwork_name != "" ? "" : var.network_name}"
-    subnetwork = "${var.subnetwork_name != "" ? var.subnetwork_name : ""}"
+    network            = "${var.subnetwork_name != "" ? "" : var.network_name}"
+    subnetwork         = "${var.subnetwork_name != "" ? var.subnetwork_name : ""}"
+    subnetwork_project = "${var.network_project_id}"
   }
 
   # For a full list of oAuth 2.0 Scopes, see https://developers.google.com/identity/protocols/googlescopes
@@ -214,7 +216,8 @@ resource "google_compute_firewall" "allow_inbound_health_check" {
 
   name    = "${var.cluster_name}-rule-health-check"
   network = "${var.network_name}"
-  project = "${var.gcp_project_id}"
+
+  project = "${var.network_project_id}"
 
   allow {
     protocol = "tcp"

--- a/modules/vault-cluster/main.tf
+++ b/modules/vault-cluster/main.tf
@@ -18,6 +18,8 @@ terraform {
 # Create the single-zone Managed Instance Group where Vault will run.
 resource "google_compute_instance_group_manager" "vault" {
   name = "${var.cluster_name}-ig"
+  
+  project = "${var.gcp_project_id}"
 
   base_instance_name = "${var.cluster_name}"
   instance_template  = "${data.template_file.compute_instance_template_self_link.rendered}"
@@ -41,6 +43,7 @@ resource "google_compute_instance_template" "vault_public" {
 
   name_prefix = "${var.cluster_name}"
   description = "${var.cluster_description}"
+  project = "${var.gcp_project_id}"
 
   instance_description = "${var.cluster_description}"
   machine_type         = "${var.machine_type}"
@@ -101,6 +104,7 @@ resource "google_compute_instance_template" "vault_private" {
 
   name_prefix = "${var.cluster_name}"
   description = "${var.cluster_description}"
+  project = "${var.gcp_project_id}"
 
   instance_description = "${var.cluster_description}"
   machine_type = "${var.machine_type}"
@@ -158,6 +162,7 @@ resource "google_compute_instance_template" "vault_private" {
 resource "google_compute_firewall" "allow_intracluster_vault" {
   name    = "${var.cluster_name}-rule-cluster"
   network = "${var.network_name}"
+  project = "${var.gcp_project_id}"
 
   allow {
     protocol = "tcp"
@@ -180,6 +185,7 @@ resource "google_compute_firewall" "allow_inbound_api" {
 
   name    = "${var.cluster_name}-rule-external-api-access"
   network = "${var.network_name}"
+  project = "${var.gcp_project_id}"
 
   allow {
     protocol = "tcp"
@@ -202,6 +208,7 @@ resource "google_compute_firewall" "allow_inbound_health_check" {
 
   name    = "${var.cluster_name}-rule-health-check"
   network = "${var.network_name}"
+  project = "${var.gcp_project_id}"
 
   allow {
     protocol = "tcp"
@@ -223,6 +230,7 @@ resource "google_storage_bucket" "vault_storage_backend" {
   name = "${var.cluster_name}"
   location = "${var.gcs_bucket_location}"
   storage_class = "${var.gcs_bucket_storage_class}"
+  project = "${var.gcp_project_id}"
 
   # In prod, the Storage Bucket should NEVER be emptied and deleted via Terraform unless you know exactly what you're doing.
   # However, for testing purposes, it's often convenient to destroy a non-empty Storage Bucket.
@@ -235,6 +243,7 @@ resource "google_storage_bucket" "vault_storage_backend" {
 resource "google_storage_bucket_acl" "vault_storage_backend" {
   bucket = "${google_storage_bucket.vault_storage_backend.name}"
   predefined_acl = "${var.gcs_bucket_predefined_acl}"
+  project = "${var.gcp_project_id}"
 }
 
 # ---------------------------------------------------------------------------------------------------------------------

--- a/modules/vault-cluster/main.tf
+++ b/modules/vault-cluster/main.tf
@@ -253,7 +253,6 @@ resource "google_storage_bucket" "vault_storage_backend" {
 resource "google_storage_bucket_acl" "vault_storage_backend" {
   bucket         = "${google_storage_bucket.vault_storage_backend.name}"
   predefined_acl = "${var.gcs_bucket_predefined_acl}"
-  project        = "${var.gcp_project_id}"
 }
 
 # ---------------------------------------------------------------------------------------------------------------------

--- a/modules/vault-cluster/main.tf
+++ b/modules/vault-cluster/main.tf
@@ -18,7 +18,7 @@ terraform {
 # Create the single-zone Managed Instance Group where Vault will run.
 resource "google_compute_instance_group_manager" "vault" {
   name = "${var.cluster_name}-ig"
-  
+
   project = "${var.gcp_project_id}"
 
   base_instance_name = "${var.cluster_name}"
@@ -43,19 +43,19 @@ resource "google_compute_instance_template" "vault_public" {
 
   name_prefix = "${var.cluster_name}"
   description = "${var.cluster_description}"
-  project = "${var.gcp_project_id}"
+  project     = "${var.gcp_project_id}"
 
   instance_description = "${var.cluster_description}"
   machine_type         = "${var.machine_type}"
 
-  tags = "${concat(list(var.cluster_tag_name), var.custom_tags)}"
+  tags                    = "${concat(list(var.cluster_tag_name), var.custom_tags)}"
   metadata_startup_script = "${var.startup_script}"
-  metadata = "${merge(map(var.metadata_key_name_for_cluster_size, var.cluster_size), var.custom_metadata)}"
+  metadata                = "${merge(map(var.metadata_key_name_for_cluster_size, var.cluster_size), var.custom_metadata)}"
 
   scheduling {
     automatic_restart   = true
     on_host_maintenance = "MIGRATE"
-    preemptible = false
+    preemptible         = false
   }
 
   disk {
@@ -68,6 +68,7 @@ resource "google_compute_instance_template" "vault_public" {
 
   network_interface {
     network = "${var.network_name}"
+
     access_config {
       # The presence of this property assigns a public IP address to each Compute Instance. We intentionally leave it
       # blank so that an external IP address is selected automatically.
@@ -77,7 +78,8 @@ resource "google_compute_instance_template" "vault_public" {
 
   # For a full list of oAuth 2.0 Scopes, see https://developers.google.com/identity/protocols/googlescopes
   service_account {
-    email  = "${var.service_account_email}"
+    email = "${var.service_account_email}"
+
     scopes = ["${concat(
       list(
         "https://www.googleapis.com/auth/userinfo.email",
@@ -103,19 +105,19 @@ resource "google_compute_instance_template" "vault_private" {
 
   name_prefix = "${var.cluster_name}"
   description = "${var.cluster_description}"
-  project = "${var.gcp_project_id}"
+  project     = "${var.gcp_project_id}"
 
   instance_description = "${var.cluster_description}"
-  machine_type = "${var.machine_type}"
+  machine_type         = "${var.machine_type}"
 
-  tags = ["${concat(list(var.cluster_tag_name), var.custom_tags)}"]
+  tags                    = ["${concat(list(var.cluster_tag_name), var.custom_tags)}"]
   metadata_startup_script = "${var.startup_script}"
-  metadata = "${merge(map(var.metadata_key_name_for_cluster_size, var.cluster_size), var.custom_metadata)}"
+  metadata                = "${merge(map(var.metadata_key_name_for_cluster_size, var.cluster_size), var.custom_metadata)}"
 
   scheduling {
     automatic_restart   = true
     on_host_maintenance = "MIGRATE"
-    preemptible = false
+    preemptible         = false
   }
 
   disk {
@@ -132,7 +134,8 @@ resource "google_compute_instance_template" "vault_private" {
 
   # For a full list of oAuth 2.0 Scopes, see https://developers.google.com/identity/protocols/googlescopes
   service_account {
-    email  = "${var.service_account_email}"
+    email = "${var.service_account_email}"
+
     scopes = ["${concat(
       list(
         "https://www.googleapis.com/auth/userinfo.email",
@@ -165,7 +168,8 @@ resource "google_compute_firewall" "allow_intracluster_vault" {
 
   allow {
     protocol = "tcp"
-    ports    = [
+
+    ports = [
       "${var.cluster_port}",
     ]
   }
@@ -188,14 +192,15 @@ resource "google_compute_firewall" "allow_inbound_api" {
 
   allow {
     protocol = "tcp"
-    ports    = [
+
+    ports = [
       "${var.api_port}",
     ]
   }
 
   source_ranges = "${var.allowed_inbound_cidr_blocks_api}"
-  source_tags = ["${var.allowed_inbound_tags_api}"]
-  target_tags = ["${var.cluster_tag_name}"]
+  source_tags   = ["${var.allowed_inbound_tags_api}"]
+  target_tags   = ["${var.cluster_tag_name}"]
 }
 
 # If we require a Load Balancer in front of the Vault cluster, we must specify a Health Check so that the Load Balancer
@@ -211,14 +216,15 @@ resource "google_compute_firewall" "allow_inbound_health_check" {
 
   allow {
     protocol = "tcp"
-    ports    = [
+
+    ports = [
       "${var.web_proxy_port}",
     ]
   }
 
   # Per https://goo.gl/xULu8U, all Google Cloud Health Check requests will be sent from 35.191.0.0/16
   source_ranges = ["35.191.0.0/16"]
-  target_tags = ["${var.cluster_tag_name}"]
+  target_tags   = ["${var.cluster_tag_name}"]
 }
 
 # ---------------------------------------------------------------------------------------------------------------------
@@ -226,10 +232,10 @@ resource "google_compute_firewall" "allow_inbound_health_check" {
 # ---------------------------------------------------------------------------------------------------------------------
 
 resource "google_storage_bucket" "vault_storage_backend" {
-  name = "${var.cluster_name}"
-  location = "${var.gcs_bucket_location}"
+  name          = "${var.cluster_name}"
+  location      = "${var.gcs_bucket_location}"
   storage_class = "${var.gcs_bucket_storage_class}"
-  project = "${var.gcp_project_id}"
+  project       = "${var.gcp_project_id}"
 
   # In prod, the Storage Bucket should NEVER be emptied and deleted via Terraform unless you know exactly what you're doing.
   # However, for testing purposes, it's often convenient to destroy a non-empty Storage Bucket.
@@ -240,9 +246,9 @@ resource "google_storage_bucket" "vault_storage_backend" {
 # does not yet expose a way to attach an IAM Policy to a Google Bucket so we resort to using the Bucket ACL in case users
 # of this module wish to limit Bucket permissions via Terraform.
 resource "google_storage_bucket_acl" "vault_storage_backend" {
-  bucket = "${google_storage_bucket.vault_storage_backend.name}"
+  bucket         = "${google_storage_bucket.vault_storage_backend.name}"
   predefined_acl = "${var.gcs_bucket_predefined_acl}"
-  project = "${var.gcp_project_id}"
+  project        = "${var.gcp_project_id}"
 }
 
 # ---------------------------------------------------------------------------------------------------------------------

--- a/modules/vault-cluster/main.tf
+++ b/modules/vault-cluster/main.tf
@@ -67,9 +67,10 @@ resource "google_compute_instance_template" "vault_public" {
   }
 
   network_interface {
+    # Either network or subnetwork must both be blank, or exactly one must be provided.
     network            = "${var.subnetwork_name != "" ? "" : var.network_name}"
     subnetwork         = "${var.subnetwork_name != "" ? var.subnetwork_name : ""}"
-    subnetwork_project = "${var.network_project_id}"
+    subnetwork_project = "${var.network_project_id != "" ? var.network_project_id : var.gcp_project_id}"
 
     access_config {
       # The presence of this property assigns a public IP address to each Compute Instance. We intentionally leave it
@@ -133,7 +134,7 @@ resource "google_compute_instance_template" "vault_private" {
   network_interface {
     network            = "${var.subnetwork_name != "" ? "" : var.network_name}"
     subnetwork         = "${var.subnetwork_name != "" ? var.subnetwork_name : ""}"
-    subnetwork_project = "${var.network_project_id}"
+    subnetwork_project = "${var.network_project_id != "" ? var.network_project_id : var.gcp_project_id}"
   }
 
   # For a full list of oAuth 2.0 Scopes, see https://developers.google.com/identity/protocols/googlescopes
@@ -192,7 +193,7 @@ resource "google_compute_firewall" "allow_inbound_api" {
 
   name    = "${var.cluster_name}-rule-external-api-access"
   network = "${var.network_name}"
-  project = "${var.network_project_id}"
+  project = "${var.network_project_id != "" ? var.network_project_id : var.gcp_project_id}"
 
   allow {
     protocol = "tcp"
@@ -217,7 +218,7 @@ resource "google_compute_firewall" "allow_inbound_health_check" {
   name    = "${var.cluster_name}-rule-health-check"
   network = "${var.network_name}"
 
-  project = "${var.network_project_id}"
+  project = "${var.network_project_id != "" ? var.network_project_id : var.gcp_project_id}"
 
   allow {
     protocol = "tcp"

--- a/modules/vault-cluster/main.tf
+++ b/modules/vault-cluster/main.tf
@@ -67,8 +67,7 @@ resource "google_compute_instance_template" "vault_public" {
   }
 
   network_interface {
-    network = "${var.subnetwork_name != "" ? "" : var.network_name}"
-    subnetwork = "${var.subnetwork_name != "" ? var.subnetwork_name : ""}"
+    network = "${var.network_name}"
     access_config {
       # The presence of this property assigns a public IP address to each Compute Instance. We intentionally leave it
       # blank so that an external IP address is selected automatically.

--- a/modules/vault-cluster/variables.tf
+++ b/modules/vault-cluster/variables.tf
@@ -11,10 +11,6 @@ variable "gcp_project_id" {
   description = "The ID of the GCP project to deploy the vault cluster to."
 }
 
-variable "network_project_id" {
-  description = "The ID of the GCP project the network is part of (mainly used for network sharing across projects)"
-}
-
 variable "cluster_name" {
   description = "The name of the Vault cluster (e.g. vault-stage). This variable is used to namespace all resources created by this module."
 }
@@ -55,6 +51,11 @@ variable "gcs_bucket_storage_class" {
 # OPTIONAL PARAMETERS
 # These parameters have reasonable defaults.
 # ---------------------------------------------------------------------------------------------------------------------
+
+variable "network_project_id" {
+  description = "The name of the GCP Project where the network is located. Useful when using networks shared between projects. If empty, var.gcp_project_id will be used."
+  default = ""
+}
 
 variable "instance_group_target_pools" {
   description = "To use a Load Balancer with the Consul cluster, you must populate this value. Specifically, this is the list of Target Pool URLs to which new Compute Instances in the Instance Group created by this module will be added. Note that updating the Target Pools attribute does not affect existing Compute Instances."

--- a/modules/vault-cluster/variables.tf
+++ b/modules/vault-cluster/variables.tf
@@ -7,6 +7,10 @@ variable "gcp_zone" {
   description = "All GCP resources will be launched in this Zone."
 }
 
+variable "gcp_project_id" {
+  description = "The ID of the GCP project to deploy the vault cluster to."
+}
+
 variable "cluster_name" {
   description = "The name of the Vault cluster (e.g. vault-stage). This variable is used to namespace all resources created by this module."
 }

--- a/modules/vault-cluster/variables.tf
+++ b/modules/vault-cluster/variables.tf
@@ -73,6 +73,11 @@ variable "network_name" {
   default = "default"
 }
 
+variable "subnetwork_name" {
+  description = "The name of the VPC Subnetwork where all resources should be created. Defaults to the default subnetwork for the network and region."
+  default = ""
+}
+
 variable "custom_tags" {
   description = "A list of tags that will be added to the Compute Instance Template in addition to the tags automatically added by this module."
   type = "list"

--- a/modules/vault-cluster/variables.tf
+++ b/modules/vault-cluster/variables.tf
@@ -73,11 +73,6 @@ variable "network_name" {
   default = "default"
 }
 
-variable "subnetwork_name" {
-  description = "The name of the VPC Subnetwork where all resources should be created. Defaults to the default subnetwork for the network and region."
-  default = ""
-}
-
 variable "custom_tags" {
   description = "A list of tags that will be added to the Compute Instance Template in addition to the tags automatically added by this module."
   type = "list"

--- a/modules/vault-cluster/variables.tf
+++ b/modules/vault-cluster/variables.tf
@@ -58,40 +58,40 @@ variable "gcs_bucket_storage_class" {
 
 variable "instance_group_target_pools" {
   description = "To use a Load Balancer with the Consul cluster, you must populate this value. Specifically, this is the list of Target Pool URLs to which new Compute Instances in the Instance Group created by this module will be added. Note that updating the Target Pools attribute does not affect existing Compute Instances."
-  type = "list"
-  default = []
+  type        = "list"
+  default     = []
 }
 
 variable "cluster_description" {
   description = "A description of the Vault cluster; it will be added to the Compute Instance Template."
-  default = ""
+  default     = ""
 }
 
 variable "assign_public_ip_addresses" {
   description = "If true, each of the Compute Instances will receive a public IP address and be reachable from the Public Internet (if Firewall rules permit). If false, the Compute Instances will have private IP addresses only. In production, this should be set to false."
-  default = false
+  default     = false
 }
 
 variable "network_name" {
   description = "The name of the VPC Network where all resources should be created."
-  default = "default"
+  default     = "default"
 }
 
 variable "subnetwork_name" {
   description = "The name of the VPC Subnetwork where all resources should be created. Defaults to the default subnetwork for the network and region."
-  default = ""
+  default     = ""
 }
 
 variable "custom_tags" {
   description = "A list of tags that will be added to the Compute Instance Template in addition to the tags automatically added by this module."
-  type = "list"
-  default = []
+  type        = "list"
+  default     = []
 }
 
 variable "service_account_scopes" {
   description = "A list of service account scopes that will be added to the Compute Instance Template in addition to the scopes automatically added by this module."
-  type = "list"
-  default = []
+  type        = "list"
+  default     = []
 }
 
 variable "service_account_email" {
@@ -101,76 +101,76 @@ variable "service_account_email" {
 
 variable "instance_group_update_strategy" {
   description = "The update strategy to be used by the Instance Group. IMPORTANT! When you update almost any cluster setting, under the hood, this module creates a new Instance Group Template. Once that Instance Group Template is created, the value of this variable determines how the new Template will be rolled out across the Instance Group. Unfortunately, as of August 2017, Google only supports the options 'RESTART' (instantly restart all Compute Instances and launch new ones from the new Template) or 'NONE' (do nothing; updates should be handled manually). Google does offer a rolling updates feature that perfectly meets our needs, but this is in Alpha (https://goo.gl/MC3mfc). Therefore, until this module supports a built-in rolling update strategy, we recommend using `NONE` and either using the alpha rolling updates strategy to roll out new Vault versions, or to script this using GCE API calls. If using the alpha feature, be sure you are comfortable with the level of risk you are taking on. For additional detail, see https://goo.gl/hGH6dd."
-  default = "NONE"
+  default     = "NONE"
 }
 
 variable "enable_web_proxy" {
   description = "If true, a Firewall Rule will be created that allows inbound Health Check traffic on var.web_proxy_port."
-  default = false
+  default     = false
 }
 
 # Metadata
 
 variable "metadata_key_name_for_cluster_size" {
   description = "The key name to be used for the custom metadata attribute that represents the size of the Vault cluster."
-  default = "cluster-size"
+  default     = "cluster-size"
 }
 
 variable "custom_metadata" {
   description = "A map of metadata key value pairs to assign to the Compute Instance metadata."
-  type = "map"
-  default = {}
+  type        = "map"
+  default     = {}
 }
 
 # Firewall Ports
 
 variable "api_port" {
   description = "The port used by Vault to handle incoming API requests."
-  default = 8200
+  default     = 8200
 }
 
 variable "cluster_port" {
   description = "The port used by Vault for server-to-server communication."
-  default = 8201
+  default     = 8201
 }
 
 variable "web_proxy_port" {
   description = "The port at which the HTTP proxy server will listen for incoming HTTP requests that will be forwarded to the Vault Health Check URL. We must have an HTTP proxy server to work around the limitation that GCP only permits Health Checks via HTTP, not HTTPS. This value is originally set in the Startup Script that runs Nginx and passes the port value there."
-  default = 8000
+  default     = 8000
 }
 
 variable "allowed_inbound_cidr_blocks_api" {
   description = "A list of CIDR-formatted IP address ranges from which the Compute Instances will allow connections to Vault on the configured TCP Listener (see https://goo.gl/Equ4xP)"
-  type = "list"
-  default = ["0.0.0.0/0"]
+  type        = "list"
+  default     = ["0.0.0.0/0"]
 }
 
 variable "allowed_inbound_tags_api" {
   description = "A list of tags from which the Compute Instances will allow connections to Vault on the configured TCP Listener (see https://goo.gl/Equ4xP)"
-  type = "list"
-  default = []
+  type        = "list"
+  default     = []
 }
 
 # Disk Settings
 
 variable "root_volume_disk_size_gb" {
   description = "The size, in GB, of the root disk volume on each Consul node."
-  default = 30
+  default     = 30
 }
 
 variable "root_volume_disk_type" {
   description = "The GCE disk type. Can be either pd-ssd, local-ssd, or pd-standard"
-  default = "pd-standard"
+  default     = "pd-standard"
 }
 
 # Google Storage Bucket Settings
 
 variable "gcs_bucket_force_destroy" {
   description = "If true, Terraform will delete the Google Cloud Storage Bucket even if it's non-empty. WARNING! Never set this to true in a production setting. We only have this option here to facilitate testing."
-  default = false
+  default     = false
 }
 
 variable "gcs_bucket_predefined_acl" {
   description = "The canned GCS Access Control List (ACL) to apply to the GCS Bucket. For a full list of Predefined ACLs, see https://cloud.google.com/storage/docs/access-control/lists."
-  default = "projectPrivate"
+  default     = "projectPrivate"
 }

--- a/modules/vault-cluster/variables.tf
+++ b/modules/vault-cluster/variables.tf
@@ -11,6 +11,10 @@ variable "gcp_project_id" {
   description = "The ID of the GCP project to deploy the vault cluster to."
 }
 
+variable "network_project_id" {
+  description = "The ID of the GCP project the network is part of (mainly used for network sharing across projects)"
+}
+
 variable "cluster_name" {
   description = "The name of the Vault cluster (e.g. vault-stage). This variable is used to namespace all resources created by this module."
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,5 +1,5 @@
 output "gcp_project_id" {
-  value = "${var.gcp_project}"
+  value = "${var.gcp_project_id}"
 }
 
 output "gcp_zone" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,4 +1,4 @@
-output "gcp_project" {
+output "gcp_project_id" {
   value = "${var.gcp_project}"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -7,6 +7,10 @@ variable "gcp_project_id" {
   description = "The name of the GCP Project where all resources will be launched."
 }
 
+variable "network_project_id" {
+  description = "The name of the GCP Project where the network is located (used for networks shared across projects)"
+}
+
 variable "gcp_region" {
   description = "The region in which all GCP resources will be launched."
 }

--- a/variables.tf
+++ b/variables.tf
@@ -3,7 +3,7 @@
 # These parameters must be supplied when consuming this module.
 # ---------------------------------------------------------------------------------------------------------------------
 
-variable "gcp_project" {
+variable "gcp_project_id" {
   description = "The name of the GCP Project where all resources will be launched."
 }
 
@@ -38,50 +38,50 @@ variable "consul_server_source_image" {
 
 variable "vault_cluster_machine_type" {
   description = "The machine type of the Compute Instance to run for each node in the Vault cluster (e.g. n1-standard-1)."
-  default = "g1-small"
+  default     = "g1-small"
 }
 
 variable "consul_server_machine_type" {
   description = "The machine type of the Compute Instance to run for each node in the Consul Server cluster (e.g. n1-standard-1)."
-  default = "g1-small"
+  default     = "g1-small"
 }
 
 variable "gcs_bucket_location" {
   description = "The location of the Google Cloud Storage Bucket where Vault secrets will be stored. For details, see https://goo.gl/hk63jH."
-  default = "US"
+  default     = "US"
 }
 
 variable "gcs_bucket_class" {
   description = "The Storage Class of the Google Cloud Storage Bucket where Vault secrets will be stored. Must be one of MULTI_REGIONAL, REGIONAL, NEARLINE, or COLDLINE. For details, see https://goo.gl/hk63jH."
-  default = "MULTI_REGIONAL"
+  default     = "MULTI_REGIONAL"
 }
 
 variable "gcs_bucket_force_destroy" {
   description = "If true, Terraform will delete the Google Cloud Storage Bucket even if it's non-empty. WARNING! Never set this to true in a production setting. We only have this option here to facilitate testing."
-  default = true
+  default     = true
 }
 
 variable "vault_cluster_size" {
   description = "The number of nodes to have in the Vault Server cluster. We strongly recommended that you use either 3 or 5."
-  default = 3
+  default     = 3
 }
 
 variable "consul_server_cluster_size" {
   description = "The number of nodes to have in the Consul Server cluster. We strongly recommended that you use either 3 or 5."
-  default = 3
+  default     = 3
 }
 
 variable "web_proxy_port" {
   description = "The port at which the HTTP proxy server will listen for incoming HTTP requests that will be forwarded to the Vault Health Check URL. We must have an HTTP proxy server to work around the limitation that GCP only permits Health Checks via HTTP, not HTTPS."
-  default = "8000"
+  default     = "8000"
 }
 
 variable "root_volume_disk_size_gb" {
   description = "The size, in GB, of the root disk volume on each Consul node."
-  default = 30
+  default     = 30
 }
 
 variable "root_volume_disk_type" {
   description = "The GCE disk type. Can be either pd-ssd, local-ssd, or pd-standard"
-  default = "pd-standard"
+  default     = "pd-standard"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -7,10 +7,6 @@ variable "gcp_project_id" {
   description = "The name of the GCP Project where all resources will be launched."
 }
 
-variable "network_project_id" {
-  description = "The name of the GCP Project where the network is located (used for networks shared across projects)"
-}
-
 variable "gcp_region" {
   description = "The region in which all GCP resources will be launched."
 }
@@ -39,6 +35,11 @@ variable "consul_server_source_image" {
 # OPTIONAL PARAMETERS
 # These parameters have reasonable defaults.
 # ---------------------------------------------------------------------------------------------------------------------
+
+variable "network_project_id" {
+  description = "The name of the GCP Project where the network is located. Useful when using networks shared between projects. If empty, var.gcp_project_id will be used."
+  default = ""
+}
 
 variable "vault_cluster_machine_type" {
   description = "The machine type of the Compute Instance to run for each node in the Vault cluster (e.g. n1-standard-1)."


### PR DESCRIPTION
# What this PR does
This MR allows specifying of which project `vault-cluster` will deploy to, by adding a project variable for each vault instance as `${var.gcp_project_id}`, as well as a project variable for the network and firewall rules, `${var.network_project_id}`.

# Why this PR is needed
The current method uses the project defined in the 'provider' block. This is good for single-project deployments, but when using `vault-cluster` with other terraform files which need deploying into other projects, there will be no project specified in `provider`. Each terraform object will have it's project specified instread. This PR will make sure that `vault-cluster` has the same ability.

