### PR TITLE
Adds validation tests to clusters

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,11 +33,19 @@ jobs:
     - attach_workspace:
         at: *workspace_root
     # Write service account creds to disk where the API expects them
+    - run: mkdir -p /tmp/logs
     - run: |
         export GOOGLE_APPLICATION_CREDENTIALS="/tmp/gcloud.json" && \
         echo $GCLOUD_SERVICE_KEY > /tmp/gcloud.json && \
-        run-go-tests --circle-ci-2 --path test
-        
+        run-go-tests --circle-ci-2 --path test | tee /tmp/logs/all.log
+    - run:
+        command: terratest_log_parser --testlog /tmp/logs/all.log --outputdir /tmp/logs
+        when: always
+    - store_artifacts:
+        path: /tmp/logs
+    - store_test_results:
+        path: /tmp/logs
+
 workflows:
   version: 2
   build-and-test:

--- a/examples/vault-cluster-private-with-public-lb/main.tf
+++ b/examples/vault-cluster-private-with-public-lb/main.tf
@@ -73,7 +73,7 @@ data "template_file" "startup_script_vault" {
     consul_cluster_tag_name = "${var.consul_server_cluster_name}"
     vault_cluster_tag_name  = "${var.vault_cluster_name}"
     web_proxy_port          = "${var.web_proxy_port}"
-    enable_vault_ui         = "${var.enable_vault_ui ? "--enable-vault-ui" : ""}"
+    enable_vault_ui         = "${var.enable_vault_ui ? "--enable-ui" : ""}"
   }
 }
 

--- a/examples/vault-cluster-private/main.tf
+++ b/examples/vault-cluster-private/main.tf
@@ -62,7 +62,7 @@ data "template_file" "startup_script_vault" {
   vars {
     consul_cluster_tag_name = "${var.consul_server_cluster_name}"
     vault_cluster_tag_name  = "${var.vault_cluster_name}"
-    enable_vault_ui         = "${var.enable_vault_ui ? "--enable-vault-ui" : ""}"
+    enable_vault_ui         = "${var.enable_vault_ui ? "--enable-ui" : ""}"
   }
 }
 

--- a/examples/vault-cluster-private/main.tf
+++ b/examples/vault-cluster-private/main.tf
@@ -6,7 +6,7 @@
 # ---------------------------------------------------------------------------------------------------------------------
 
 provider "google" {
-  project = "${var.gcp_project}"
+  project = "${var.gcp_project_id}"
   region  = "${var.gcp_region}"
 }
 
@@ -26,7 +26,8 @@ module "vault_cluster" {
   # source = "git::git@github.com:hashicorp/terraform-google-vault.git//modules/vault-cluster?ref=v0.0.1"
   source = "../../modules/vault-cluster"
 
-  gcp_region = "${var.gcp_region}"
+  gcp_project_id = "${var.gcp_project_id}"
+  gcp_region     = "${var.gcp_region}"
 
   cluster_name     = "${var.vault_cluster_name}"
   cluster_size     = "${var.vault_cluster_size}"

--- a/examples/vault-cluster-private/main.tf
+++ b/examples/vault-cluster-private/main.tf
@@ -17,6 +17,48 @@ terraform {
 }
 
 # ---------------------------------------------------------------------------------------------------------------------
+# CREATES A SUBNETWORK WITH GOOGLE API ACCESS
+# Necessary because the private cluster doesn't have internet access
+# But consul needs to make requests to the Google API
+# ---------------------------------------------------------------------------------------------------------------------
+
+resource "google_compute_subnetwork" "private_subnet_with_google_api_access" {
+  name                     = "${var.vault_cluster_name}-private-subnet-with-google-api-access"
+  private_ip_google_access = true
+  network                  = "${var.network_name}"
+  ip_cidr_range            = "10.1.0.0/16"
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# DEPLOY A BASTION HOST THAT CAN REACH THE CLUSTER
+# We can't ssh directly to the cluster because they don't have an external IP
+# address, but we can ssh to a bastion host inside the same subnet and then
+# access the cluster
+# ---------------------------------------------------------------------------------------------------------------------
+
+data "google_compute_zones" "available" {}
+
+resource "google_compute_instance" "bastion" {
+  name         = "${var.bastion_server_name}"
+  zone         = "${data.google_compute_zones.available.names[0]}"
+  machine_type = "g1-small"
+
+  boot_disk {
+    initialize_params {
+      image = "ubuntu-1810-cosmic-v20181114"
+    }
+  }
+
+  network_interface {
+    subnetwork = "${google_compute_subnetwork.private_subnet_with_google_api_access.self_link}"
+
+    access_config {
+      // Ephemeral IP - leaving this block empty will generate a new external IP and assign it to the machine
+    }
+  }
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
 # DEPLOY THE VAULT SERVER CLUSTER
 # ---------------------------------------------------------------------------------------------------------------------
 
@@ -25,6 +67,8 @@ module "vault_cluster" {
   # to a specific version of the modules, such as the following example:
   # source = "git::git@github.com:hashicorp/terraform-google-vault.git//modules/vault-cluster?ref=v0.0.1"
   source = "../../modules/vault-cluster"
+
+  subnetwork_name = "${google_compute_subnetwork.private_subnet_with_google_api_access.name}"
 
   gcp_project_id = "${var.gcp_project_id}"
   gcp_region     = "${var.gcp_region}"
@@ -73,6 +117,8 @@ data "template_file" "startup_script_vault" {
 
 module "consul_cluster" {
   source = "git::git@github.com:hashicorp/terraform-google-consul.git//modules/consul-cluster?ref=v0.2.0"
+
+  subnetwork_name = "${google_compute_subnetwork.private_subnet_with_google_api_access.name}"
 
   gcp_region = "${var.gcp_region}"
 

--- a/examples/vault-cluster-private/outputs.tf
+++ b/examples/vault-cluster-private/outputs.tf
@@ -14,6 +14,10 @@ output "cluster_tag_name" {
   value = "${module.vault_cluster.cluster_tag_name}"
 }
 
+output "bastion_server_name" {
+  value = "${var.bastion_server_name}"
+}
+
 output "instance_group_id" {
   value = "${module.vault_cluster.instance_group_id}"
 }

--- a/examples/vault-cluster-private/outputs.tf
+++ b/examples/vault-cluster-private/outputs.tf
@@ -1,5 +1,5 @@
-output "gcp_project" {
-  value = "${var.gcp_project}"
+output "gcp_project_id" {
+  value = "${var.gcp_project_id}"
 }
 
 output "gcp_region" {

--- a/examples/vault-cluster-private/variables.tf
+++ b/examples/vault-cluster-private/variables.tf
@@ -3,7 +3,7 @@
 # These parameters must be supplied when consuming this module.
 # ---------------------------------------------------------------------------------------------------------------------
 
-variable "gcp_project" {
+variable "gcp_project_id" {
   description = "The name of the GCP Project where all resources will be launched."
 }
 

--- a/examples/vault-cluster-private/variables.tf
+++ b/examples/vault-cluster-private/variables.tf
@@ -11,6 +11,10 @@ variable "gcp_region" {
   description = "The Region in which all GCP resources will be launched."
 }
 
+variable "bastion_server_name" {
+  description = "The name of the bastion server that can reach the private vault cluster"
+}
+
 variable "vault_cluster_name" {
   description = "The name of the Consul Server cluster. All resources will be namespaced by this value. E.g. consul-server-prod"
 }
@@ -78,4 +82,9 @@ variable "root_volume_disk_type" {
 variable "enable_vault_ui" {
   description = "If true, enable the Vault UI"
   default     = true
+}
+
+variable "network_name" {
+  description = "The name of the VPC Network where all resources should be created."
+  default     = "default"
 }

--- a/examples/vault-consul-image/vault-consul.json
+++ b/examples/vault-consul-image/vault-consul.json
@@ -3,9 +3,9 @@
   "variables": {
     "project_id": null,
     "zone": null,
-    "vault_version": "0.11.1",
-    "consul_module_version": "v0.2.0",
-    "consul_version": "1.2.2",
+    "vault_version": "0.11.5",
+    "consul_module_version": "v0.3.1",
+    "consul_version": "1.3.1",
     "ca_public_key_path": null,
     "tls_public_key_path": null,
     "tls_private_key_path": null
@@ -21,9 +21,12 @@
     "ssh_username": "ubuntu"
   }],
   "provisioners": [{
+    "type": "shell",
+    "inline": ["mkdir -p /tmp/terraform-google-vault/modules"]
+  },{
     "type": "file",
-    "source": "{{template_dir}}/../../../terraform-google-vault",
-    "destination": "/tmp",
+    "source": "{{template_dir}}/../../modules/",
+    "destination": "/tmp/terraform-google-vault/modules",
     "pause_before": "30s"
   },{
     "type": "shell",

--- a/main.tf
+++ b/main.tf
@@ -24,9 +24,8 @@ module "vault_cluster" {
   # source = "git::git@github.com:hashicorp/terraform-google-vault.git//modules/vault-cluster?ref=v0.0.1"
   source = "modules/vault-cluster"
 
-  gcp_project_id     = "${var.gcp_project_id}"
-  network_project_id = "${var.network_project_id}"
-  gcp_region         = "${var.gcp_region}"
+  gcp_project_id = "${var.gcp_project_id}"
+  gcp_region     = "${var.gcp_region}"
 
   cluster_name     = "${var.vault_cluster_name}"
   cluster_size     = "${var.vault_cluster_size}"

--- a/main.tf
+++ b/main.tf
@@ -63,7 +63,7 @@ data "template_file" "startup_script_vault" {
     consul_cluster_tag_name = "${var.consul_server_cluster_name}"
     vault_cluster_tag_name  = "${var.vault_cluster_name}"
 
-    enable_vault_ui = "${var.enable_vault_ui ? "--enable-vault-ui" : ""}"
+    enable_vault_ui = "${var.enable_vault_ui ? "--enable-ui" : ""}"
   }
 }
 

--- a/modules/vault-cluster/main.tf
+++ b/modules/vault-cluster/main.tf
@@ -169,7 +169,7 @@ resource "google_compute_instance_template" "vault_private" {
 resource "google_compute_firewall" "allow_intracluster_vault" {
   name    = "${var.cluster_name}-rule-cluster"
   network = "${var.network_name}"
-  project = "${var.network_project_id}"
+  project = "${var.network_project_id != "" ? var.network_project_id : var.gcp_project_id}"
 
   allow {
     protocol = "tcp"

--- a/test/Gopkg.lock
+++ b/test/Gopkg.lock
@@ -2,7 +2,6 @@
 
 
 [[projects]]
-  digest = "1:ad676a8a8a37b6e10e71a52e014ded88ce0027463c66a50011bf844843a89736"
   name = "cloud.google.com/go"
   packages = [
     "compute/metadata",
@@ -11,14 +10,12 @@
     "internal/optional",
     "internal/trace",
     "internal/version",
-    "storage",
+    "storage"
   ]
-  pruneopts = "UT"
   revision = "64a2037ec6be8a4b0c1d1f706ed35b428b989239"
   version = "v0.26.0"
 
 [[projects]]
-  digest = "1:2a7787c8b3f59a6cc50bbc039b69f35ca4b23f295d7a6332ca299c8d3dae72ce"
   name = "github.com/aws/aws-sdk-go"
   packages = [
     "aws",
@@ -66,42 +63,34 @@
     "service/s3/s3manager",
     "service/sns",
     "service/sqs",
-    "service/sts",
+    "service/sts"
   ]
-  pruneopts = "UT"
   revision = "4b4fb865e4e4a972645dba0b9677e623dd83a8a8"
   version = "v1.15.53"
 
 [[projects]]
-  digest = "1:7b94d37d65c0445053c6f3e73090e3966c1c29127035492c349e14f25c440359"
   name = "github.com/boombuler/barcode"
   packages = [
     ".",
     "qr",
-    "utils",
+    "utils"
   ]
-  pruneopts = "UT"
   revision = "3cfea5ab600ae37946be2b763b8ec2c1cf2d272d"
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:b98e7574fc27ec166fb31195ec72c3bd0bffd73926d3612eb4c929bc5236f75b"
   name = "github.com/go-ini/ini"
   packages = ["."]
-  pruneopts = "UT"
   revision = "7b294651033cd7d9e7f0d9ffa1b75ed1e198e737"
   version = "v1.38.3"
 
 [[projects]]
-  digest = "1:adea5a94903eb4384abef30f3d878dc9ff6b6b5b0722da25b82e5169216dfb61"
   name = "github.com/go-sql-driver/mysql"
   packages = ["."]
-  pruneopts = "UT"
   revision = "d523deb1b23d913de5bdada721a6071e71283618"
   version = "v1.4.0"
 
 [[projects]]
-  digest = "1:5d1b5a25486fc7d4e133646d834f6fca7ba1cef9903d40e7aa786c41b89e9e91"
   name = "github.com/golang/protobuf"
   packages = [
     "proto",
@@ -109,44 +98,36 @@
     "ptypes",
     "ptypes/any",
     "ptypes/duration",
-    "ptypes/timestamp",
+    "ptypes/timestamp"
   ]
-  pruneopts = "UT"
   revision = "aa810b61a9c79d51363740d207bb46cf8e620ed5"
   version = "v1.2.0"
 
 [[projects]]
   branch = "master"
-  digest = "1:4a0c6bb4805508a6287675fac876be2ac1182539ca8a32468d8128882e9d5009"
   name = "github.com/golang/snappy"
   packages = ["."]
-  pruneopts = "UT"
   revision = "2e65f85255dbc3072edf28d6b5b8efc472979f5a"
 
 [[projects]]
-  digest = "1:8f8811f9be822914c3a25c6a071e93beb4c805d7b026cbf298bc577bc1cc945b"
   name = "github.com/google/uuid"
   packages = ["."]
-  pruneopts = "UT"
   revision = "064e2069ce9c359c118179501254f67d7d37ba24"
   version = "0.2"
 
 [[projects]]
-  digest = "1:e145e9710a10bc114a6d3e2738aadf8de146adaa031854ffdf7bbfe15da85e63"
   name = "github.com/googleapis/gax-go"
   packages = ["."]
-  pruneopts = "UT"
   revision = "317e0006254c44a0ac427cc52a0e083ff0b9622f"
   version = "v2.0.0"
 
 [[projects]]
-  branch = "symlinks"
-  digest = "1:c68969b1e245f236a8d432f81d9925e057f8069c24d265fc832b23d1b817b4d0"
   name = "github.com/gruntwork-io/terratest"
   packages = [
     "modules/aws",
     "modules/collections",
     "modules/customerrors",
+    "modules/environment",
     "modules/files",
     "modules/gcp",
     "modules/logger",
@@ -156,61 +137,48 @@
     "modules/shell",
     "modules/ssh",
     "modules/terraform",
-    "modules/test-structure",
+    "modules/test-structure"
   ]
-  pruneopts = "UT"
-  revision = "1f2ad52df2c41f25f1ef98246afc382b56b28383"
+  revision = "41439c5e9e1d0fa4a07f9bbc6b38e8f0ef7e93ef"
+  version = "v0.13.13"
 
 [[projects]]
-  digest = "1:0ade334594e69404d80d9d323445d2297ff8161637f9b2d347cc6973d2d6f05b"
   name = "github.com/hashicorp/errwrap"
   packages = ["."]
-  pruneopts = "UT"
   revision = "8a6fb523712970c966eefc6b39ed2c5e74880354"
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:f47d6109c2034cb16bd62b220e18afd5aa9d5a1630fe5d937ad96a4fb7cbb277"
   name = "github.com/hashicorp/go-cleanhttp"
   packages = ["."]
-  pruneopts = "UT"
   revision = "e8ab9daed8d1ddd2d3c4efba338fe2eeae2e4f18"
   version = "v0.5.0"
 
 [[projects]]
-  digest = "1:f668349b83f7d779567c880550534addeca7ebadfdcf44b0b9c39be61864b4b7"
   name = "github.com/hashicorp/go-multierror"
   packages = ["."]
-  pruneopts = "UT"
   revision = "886a7fbe3eb1c874d46f623bfa70af45f425b3d1"
   version = "v1.0.0"
 
 [[projects]]
   branch = "master"
-  digest = "1:183f00c472fb9b2446659618eebf4899872fa267b92f926539411abdc8b941df"
   name = "github.com/hashicorp/go-retryablehttp"
   packages = ["."]
-  pruneopts = "UT"
   revision = "e651d75abec6fbd4f2c09508f72ae7af8a8b7171"
 
 [[projects]]
   branch = "master"
-  digest = "1:45aad874d3c7d5e8610427c81870fb54970b981692930ec2a319ce4cb89d7a00"
   name = "github.com/hashicorp/go-rootcerts"
   packages = ["."]
-  pruneopts = "UT"
   revision = "6bb64b370b90e7ef1fa532be9e591a81c3493e00"
 
 [[projects]]
   branch = "master"
-  digest = "1:14f2005c31ddf99c4a0f36fc440f8d1ac43224194c7c4a904b3c8f4ba5654d0b"
   name = "github.com/hashicorp/go-sockaddr"
   packages = ["."]
-  pruneopts = "UT"
   revision = "6d291a969b86c4b633730bfc6b8b9d64c3aafed9"
 
 [[projects]]
-  digest = "1:ea40c24cdbacd054a6ae9de03e62c5f252479b96c716375aace5c120d68647c8"
   name = "github.com/hashicorp/hcl"
   packages = [
     ".",
@@ -221,14 +189,12 @@
     "hcl/token",
     "json/parser",
     "json/scanner",
-    "json/token",
+    "json/token"
   ]
-  pruneopts = "UT"
   revision = "8cb6e5b959231cc1119e43259c4a608f9c51a241"
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:132b0071e7d37a931d2e9c747d766c2a8413976e48d98388be4e8d6c0d1193ec"
   name = "github.com/hashicorp/vault"
   packages = [
     "api",
@@ -237,68 +203,54 @@
     "helper/hclutil",
     "helper/jsonutil",
     "helper/parseutil",
-    "helper/strutil",
+    "helper/strutil"
   ]
-  pruneopts = "UT"
   revision = "fb601237bfbe4bc16ff679f642248ee8a86e627b"
   version = "v0.11.3"
 
 [[projects]]
-  digest = "1:e22af8c7518e1eab6f2eab2b7d7558927f816262586cd6ed9f349c97a6c285c4"
   name = "github.com/jmespath/go-jmespath"
   packages = ["."]
-  pruneopts = "UT"
   revision = "0b12d6b5"
 
 [[projects]]
-  digest = "1:78bbb1ba5b7c3f2ed0ea1eab57bdd3859aec7e177811563edc41198a760b06af"
   name = "github.com/mitchellh/go-homedir"
   packages = ["."]
-  pruneopts = "UT"
   revision = "ae18d6b8b3205b561c79e8e5f69bff09736185f4"
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:53bc4cd4914cd7cd52139990d5170d6dc99067ae31c56530621b18b35fc30318"
   name = "github.com/mitchellh/mapstructure"
   packages = ["."]
-  pruneopts = "UT"
   revision = "3536a929edddb9a5b34bd6861dc4a9647cb459fe"
   version = "v1.1.2"
 
 [[projects]]
-  digest = "1:e39a5ee8fcbec487f8fc68863ef95f2b025e0739b0e4aa55558a2b4cf8f0ecf0"
   name = "github.com/pierrec/lz4"
   packages = [
     ".",
-    "internal/xxh32",
+    "internal/xxh32"
   ]
-  pruneopts = "UT"
   revision = "635575b42742856941dbc767b44905bb9ba083f6"
   version = "v2.0.7"
 
 [[projects]]
-  digest = "1:6c7a3f738e37a1c7ad3d56122a34932140654d51a57e01f8613cdf3eaf050911"
   name = "github.com/pquerna/otp"
   packages = [
     ".",
     "hotp",
-    "totp",
+    "totp"
   ]
-  pruneopts = "UT"
   revision = "b7b89250c468c06871d3837bee02e2d5c155ae19"
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:0e792eea6c96ec55ff302ef33886acbaa5006e900fefe82689e88d96439dcd84"
   name = "github.com/ryanuber/go-glob"
   packages = ["."]
-  pruneopts = "UT"
   revision = "572520ed46dbddaed19ea3d9541bdd0494163693"
   version = "v0.1"
 
 [[projects]]
-  digest = "1:ac5cb21cbe4f095b6e5f1ae5102a85dfd598d39b5ad0d64df3d41ee046586f30"
   name = "go.opencensus.io"
   packages = [
     ".",
@@ -313,15 +265,13 @@
     "trace",
     "trace/internal",
     "trace/propagation",
-    "trace/tracestate",
+    "trace/tracestate"
   ]
-  pruneopts = "UT"
   revision = "79993219becaa7e29e3b60cb67f5b8e82dee11d6"
   version = "v0.17.0"
 
 [[projects]]
   branch = "master"
-  digest = "1:5bfe7889c6059903d067d47a0a66f07a0851f47fd38f0ba5c77f402fb3d46a2d"
   name = "golang.org/x/crypto"
   packages = [
     "curve25519",
@@ -331,14 +281,12 @@
     "internal/subtle",
     "poly1305",
     "ssh",
-    "ssh/agent",
+    "ssh/agent"
   ]
-  pruneopts = "UT"
   revision = "7c1a557ab941a71c619514f229f0b27ccb0c27cf"
 
 [[projects]]
   branch = "master"
-  digest = "1:1ae047ded1ddcbe0eca8b0772e3ff2c10e354db4c42c65b96d0386883e63904d"
   name = "golang.org/x/net"
   packages = [
     "context",
@@ -348,35 +296,28 @@
     "http2/hpack",
     "idna",
     "internal/timeseries",
-    "trace",
+    "trace"
   ]
-  pruneopts = "UT"
   revision = "49bb7cea24b1df9410e1712aa6433dae904ff66a"
 
 [[projects]]
-  branch = "master"
-  digest = "1:39273b3e6c96fed52bd8f7793fc463c40b1a27a7caa51302b81d45306b9646b4"
   name = "golang.org/x/oauth2"
   packages = [
     ".",
     "google",
     "internal",
     "jws",
-    "jwt",
+    "jwt"
   ]
-  pruneopts = "UT"
-  revision = "c57b0facaced709681d9f90397429b9430a74754"
+  revision = "d2e6202438beef2727060aa7cabdd924d92ebfd9"
 
 [[projects]]
   branch = "master"
-  digest = "1:0a40b0bdd57a93e741d8557465be3a2edeec408e9b6399586ad65bbe8e355796"
   name = "golang.org/x/sys"
   packages = ["unix"]
-  pruneopts = "UT"
   revision = "fa43e7bc11baaae89f3f902b2b4d832b68234844"
 
 [[projects]]
-  digest = "1:a2ab62866c75542dd18d2b069fec854577a20211d7c0ea6ae746072a1dccdd18"
   name = "golang.org/x/text"
   packages = [
     "collate",
@@ -392,23 +333,19 @@
     "unicode/bidi",
     "unicode/cldr",
     "unicode/norm",
-    "unicode/rangetable",
+    "unicode/rangetable"
   ]
-  pruneopts = "UT"
   revision = "f21a4dfb5e38f5895301dc265a8def02365cc3d0"
   version = "v0.3.0"
 
 [[projects]]
   branch = "master"
-  digest = "1:c9e7a4b4d47c0ed205d257648b0e5b0440880cb728506e318f8ac7cd36270bc4"
   name = "golang.org/x/time"
   packages = ["rate"]
-  pruneopts = "UT"
   revision = "fbb02b2291d28baffd63558aa44b4b56f178d650"
 
 [[projects]]
   branch = "master"
-  digest = "1:685f3f61eb1df6fb44304b9cc84e891b7493b7eba0b881260f1eceab929d1698"
   name = "google.golang.org/api"
   packages = [
     "compute/v1",
@@ -421,13 +358,11 @@
     "option",
     "storage/v1",
     "transport/http",
-    "transport/http/internal/propagation",
+    "transport/http/internal/propagation"
   ]
-  pruneopts = "UT"
   revision = "72df7e5ac770e49326116145ee04771cf1913a73"
 
 [[projects]]
-  digest = "1:0f4f3b6db668adf3c54bf3faf8d9d4f75107bee6316cce716326b5dbc4b92cfb"
   name = "google.golang.org/appengine"
   packages = [
     ".",
@@ -440,27 +375,23 @@
     "internal/modules",
     "internal/remote_api",
     "internal/urlfetch",
-    "urlfetch",
+    "urlfetch"
   ]
-  pruneopts = "UT"
   revision = "ae0ab99deb4dc413a2b4bd6c8bdd0eb67f1e4d06"
   version = "v1.2.0"
 
 [[projects]]
   branch = "master"
-  digest = "1:a58c1a53a58f69e1b9396b18b2a9cf7dd591a12d0a8f6a57322a7a6571a4c610"
   name = "google.golang.org/genproto"
   packages = [
     "googleapis/api/annotations",
     "googleapis/iam/v1",
     "googleapis/rpc/code",
-    "googleapis/rpc/status",
+    "googleapis/rpc/status"
   ]
-  pruneopts = "UT"
   revision = "af9cb2a35e7f169ec875002c1829c9b315cddc04"
 
 [[projects]]
-  digest = "1:ab8e92d746fb5c4c18846b0879842ac8e53b3d352449423d0924a11f1020ae1b"
   name = "google.golang.org/grpc"
   packages = [
     ".",
@@ -488,25 +419,14 @@
     "resolver/passthrough",
     "stats",
     "status",
-    "tap",
+    "tap"
   ]
-  pruneopts = "UT"
   revision = "8dea3dc473e90c8179e519d91302d0597c0ca1d1"
   version = "v1.15.0"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  input-imports = [
-    "github.com/gruntwork-io/terratest/modules/gcp",
-    "github.com/gruntwork-io/terratest/modules/logger",
-    "github.com/gruntwork-io/terratest/modules/packer",
-    "github.com/gruntwork-io/terratest/modules/random",
-    "github.com/gruntwork-io/terratest/modules/retry",
-    "github.com/gruntwork-io/terratest/modules/ssh",
-    "github.com/gruntwork-io/terratest/modules/terraform",
-    "github.com/gruntwork-io/terratest/modules/test-structure",
-    "github.com/hashicorp/vault/api",
-  ]
+  inputs-digest = "63c9723ee18e1b58c0ec02134856bb90dbf85480a21c180c28b9db4d5f71c621"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/test/Gopkg.lock
+++ b/test/Gopkg.lock
@@ -140,7 +140,8 @@
   version = "v2.0.0"
 
 [[projects]]
-  digest = "1:5260e677528214ab8458d7ded3ebc2d3c1093d0f1802434b209b3b423b720328"
+  branch = "symlinks"
+  digest = "1:c68969b1e245f236a8d432f81d9925e057f8069c24d265fc832b23d1b817b4d0"
   name = "github.com/gruntwork-io/terratest"
   packages = [
     "modules/aws",
@@ -158,8 +159,7 @@
     "modules/test-structure",
   ]
   pruneopts = "UT"
-  revision = "e8affd7c6e4b96e0504300e99e6113d7b5d0722f"
-  version = "v0.13.4"
+  revision = "1f2ad52df2c41f25f1ef98246afc382b56b28383"
 
 [[projects]]
   digest = "1:0ade334594e69404d80d9d323445d2297ff8161637f9b2d347cc6973d2d6f05b"

--- a/test/Gopkg.lock
+++ b/test/Gopkg.lock
@@ -116,6 +116,14 @@
   version = "v1.2.0"
 
 [[projects]]
+  branch = "master"
+  digest = "1:4a0c6bb4805508a6287675fac876be2ac1182539ca8a32468d8128882e9d5009"
+  name = "github.com/golang/snappy"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "2e65f85255dbc3072edf28d6b5b8efc472979f5a"
+
+[[projects]]
   digest = "1:8f8811f9be822914c3a25c6a071e93beb4c805d7b026cbf298bc577bc1cc945b"
   name = "github.com/google/uuid"
   packages = ["."]
@@ -132,7 +140,7 @@
   version = "v2.0.0"
 
 [[projects]]
-  digest = "1:8d271b2ab59ad3cbb656e184831e75068a88d189268f352bdd9f2ef4daebbf7e"
+  digest = "1:5260e677528214ab8458d7ded3ebc2d3c1093d0f1802434b209b3b423b720328"
   name = "github.com/gruntwork-io/terratest"
   packages = [
     "modules/aws",
@@ -150,8 +158,90 @@
     "modules/test-structure",
   ]
   pruneopts = "UT"
-  revision = "12218e23e6cf6877e7804c5145d67cd01e084149"
-  version = "v0.13.0"
+  revision = "e8affd7c6e4b96e0504300e99e6113d7b5d0722f"
+  version = "v0.13.4"
+
+[[projects]]
+  digest = "1:0ade334594e69404d80d9d323445d2297ff8161637f9b2d347cc6973d2d6f05b"
+  name = "github.com/hashicorp/errwrap"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "8a6fb523712970c966eefc6b39ed2c5e74880354"
+  version = "v1.0.0"
+
+[[projects]]
+  digest = "1:f47d6109c2034cb16bd62b220e18afd5aa9d5a1630fe5d937ad96a4fb7cbb277"
+  name = "github.com/hashicorp/go-cleanhttp"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "e8ab9daed8d1ddd2d3c4efba338fe2eeae2e4f18"
+  version = "v0.5.0"
+
+[[projects]]
+  digest = "1:f668349b83f7d779567c880550534addeca7ebadfdcf44b0b9c39be61864b4b7"
+  name = "github.com/hashicorp/go-multierror"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "886a7fbe3eb1c874d46f623bfa70af45f425b3d1"
+  version = "v1.0.0"
+
+[[projects]]
+  branch = "master"
+  digest = "1:183f00c472fb9b2446659618eebf4899872fa267b92f926539411abdc8b941df"
+  name = "github.com/hashicorp/go-retryablehttp"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "e651d75abec6fbd4f2c09508f72ae7af8a8b7171"
+
+[[projects]]
+  branch = "master"
+  digest = "1:45aad874d3c7d5e8610427c81870fb54970b981692930ec2a319ce4cb89d7a00"
+  name = "github.com/hashicorp/go-rootcerts"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "6bb64b370b90e7ef1fa532be9e591a81c3493e00"
+
+[[projects]]
+  branch = "master"
+  digest = "1:14f2005c31ddf99c4a0f36fc440f8d1ac43224194c7c4a904b3c8f4ba5654d0b"
+  name = "github.com/hashicorp/go-sockaddr"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "6d291a969b86c4b633730bfc6b8b9d64c3aafed9"
+
+[[projects]]
+  digest = "1:ea40c24cdbacd054a6ae9de03e62c5f252479b96c716375aace5c120d68647c8"
+  name = "github.com/hashicorp/hcl"
+  packages = [
+    ".",
+    "hcl/ast",
+    "hcl/parser",
+    "hcl/scanner",
+    "hcl/strconv",
+    "hcl/token",
+    "json/parser",
+    "json/scanner",
+    "json/token",
+  ]
+  pruneopts = "UT"
+  revision = "8cb6e5b959231cc1119e43259c4a608f9c51a241"
+  version = "v1.0.0"
+
+[[projects]]
+  digest = "1:132b0071e7d37a931d2e9c747d766c2a8413976e48d98388be4e8d6c0d1193ec"
+  name = "github.com/hashicorp/vault"
+  packages = [
+    "api",
+    "helper/compressutil",
+    "helper/consts",
+    "helper/hclutil",
+    "helper/jsonutil",
+    "helper/parseutil",
+    "helper/strutil",
+  ]
+  pruneopts = "UT"
+  revision = "fb601237bfbe4bc16ff679f642248ee8a86e627b"
+  version = "v0.11.3"
 
 [[projects]]
   digest = "1:e22af8c7518e1eab6f2eab2b7d7558927f816262586cd6ed9f349c97a6c285c4"
@@ -159,6 +249,33 @@
   packages = ["."]
   pruneopts = "UT"
   revision = "0b12d6b5"
+
+[[projects]]
+  digest = "1:78bbb1ba5b7c3f2ed0ea1eab57bdd3859aec7e177811563edc41198a760b06af"
+  name = "github.com/mitchellh/go-homedir"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "ae18d6b8b3205b561c79e8e5f69bff09736185f4"
+  version = "v1.0.0"
+
+[[projects]]
+  digest = "1:53bc4cd4914cd7cd52139990d5170d6dc99067ae31c56530621b18b35fc30318"
+  name = "github.com/mitchellh/mapstructure"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "3536a929edddb9a5b34bd6861dc4a9647cb459fe"
+  version = "v1.1.2"
+
+[[projects]]
+  digest = "1:e39a5ee8fcbec487f8fc68863ef95f2b025e0739b0e4aa55558a2b4cf8f0ecf0"
+  name = "github.com/pierrec/lz4"
+  packages = [
+    ".",
+    "internal/xxh32",
+  ]
+  pruneopts = "UT"
+  revision = "635575b42742856941dbc767b44905bb9ba083f6"
+  version = "v2.0.7"
 
 [[projects]]
   digest = "1:6c7a3f738e37a1c7ad3d56122a34932140654d51a57e01f8613cdf3eaf050911"
@@ -171,6 +288,14 @@
   pruneopts = "UT"
   revision = "b7b89250c468c06871d3837bee02e2d5c155ae19"
   version = "v1.0.0"
+
+[[projects]]
+  digest = "1:0e792eea6c96ec55ff302ef33886acbaa5006e900fefe82689e88d96439dcd84"
+  name = "github.com/ryanuber/go-glob"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "572520ed46dbddaed19ea3d9541bdd0494163693"
+  version = "v0.1"
 
 [[projects]]
   digest = "1:ac5cb21cbe4f095b6e5f1ae5102a85dfd598d39b5ad0d64df3d41ee046586f30"
@@ -275,6 +400,14 @@
 
 [[projects]]
   branch = "master"
+  digest = "1:c9e7a4b4d47c0ed205d257648b0e5b0440880cb728506e318f8ac7cd36270bc4"
+  name = "golang.org/x/time"
+  packages = ["rate"]
+  pruneopts = "UT"
+  revision = "fbb02b2291d28baffd63558aa44b4b56f178d650"
+
+[[projects]]
+  branch = "master"
   digest = "1:685f3f61eb1df6fb44304b9cc84e891b7493b7eba0b881260f1eceab929d1698"
   name = "google.golang.org/api"
   packages = [
@@ -366,10 +499,14 @@
   analyzer-version = 1
   input-imports = [
     "github.com/gruntwork-io/terratest/modules/gcp",
+    "github.com/gruntwork-io/terratest/modules/logger",
     "github.com/gruntwork-io/terratest/modules/packer",
     "github.com/gruntwork-io/terratest/modules/random",
+    "github.com/gruntwork-io/terratest/modules/retry",
+    "github.com/gruntwork-io/terratest/modules/ssh",
     "github.com/gruntwork-io/terratest/modules/terraform",
     "github.com/gruntwork-io/terratest/modules/test-structure",
+    "github.com/hashicorp/vault/api",
   ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/test/Gopkg.toml
+++ b/test/Gopkg.toml
@@ -27,7 +27,9 @@
 
 [[constraint]]
   name = "github.com/gruntwork-io/terratest"
-  version = "0.13.4"
+  branch = "symlinks"
+  # TODO: Update to newest Terratest release
+  #version = "0.13.4"
 
 [prune]
   go-tests = true

--- a/test/Gopkg.toml
+++ b/test/Gopkg.toml
@@ -27,9 +27,7 @@
 
 [[constraint]]
   name = "github.com/gruntwork-io/terratest"
-  branch = "symlinks"
-  # TODO: Update to newest Terratest release
-  #version = "0.13.4"
+  version = "0.13.13"
 
 [prune]
   go-tests = true

--- a/test/Gopkg.toml
+++ b/test/Gopkg.toml
@@ -27,7 +27,7 @@
 
 [[constraint]]
   name = "github.com/gruntwork-io/terratest"
-  version = "0.13.0"
+  version = "0.13.4"
 
 [prune]
   go-tests = true

--- a/test/terratest_helpers.go
+++ b/test/terratest_helpers.go
@@ -87,6 +87,7 @@ func getFilesFromInstance(t *testing.T, instance *gcp.Instance, keyPair *ssh.Key
 }
 
 func writeLogFile(t *testing.T, buffer string, destination string) {
+	logger.Logf(t, fmt.Sprintf("Writing log file to %s", destination))
 	file, err := os.Create(destination)
 	if err != nil {
 		logger.Logf(t, fmt.Sprintf("Error creating log file on disk: %s", err.Error()))

--- a/test/terratest_helpers.go
+++ b/test/terratest_helpers.go
@@ -77,9 +77,13 @@ func getFilesFromInstance(t *testing.T, instance *gcp.Instance, keyPair *ssh.Key
 		Hostname:    publicIp,
 	}
 
-	useSudo := true
+	useSudo := false
+	filesFromtInstance, err := ssh.FetchContentsOfFilesE(t, host, useSudo, filePaths...)
+	if err != nil {
+		logger.Logf(t, fmt.Sprintf("Error getting log file from instance: %s", err.Error()))
+	}
 
-	return ssh.FetchContentsOfFiles(t, host, useSudo, filePaths...)
+	return filesFromtInstance
 }
 
 func writeLogFile(t *testing.T, buffer string, destination string) {

--- a/test/terratest_helpers.go
+++ b/test/terratest_helpers.go
@@ -149,3 +149,10 @@ func getInstancesFromGroup(t *testing.T, projectId string, instanceGroup *gcp.Re
 
 	return instances
 }
+
+func runCommand(t *testing.T, bastionHost *ssh.Host, targetHost *ssh.Host, command string) (string, error) {
+	if bastionHost == nil {
+		return ssh.CheckSshCommandE(t, *targetHost, command)
+	}
+	return ssh.CheckPrivateSshConnectionE(t, *bastionHost, *targetHost, command)
+}

--- a/test/terratest_helpers.go
+++ b/test/terratest_helpers.go
@@ -1,9 +1,16 @@
 package test
 
 import (
+	"fmt"
+	"os"
 	"testing"
+	"time"
 
+	"github.com/gruntwork-io/terratest/modules/gcp"
+	"github.com/gruntwork-io/terratest/modules/logger"
 	"github.com/gruntwork-io/terratest/modules/packer"
+	"github.com/gruntwork-io/terratest/modules/retry"
+	"github.com/gruntwork-io/terratest/modules/ssh"
 	"github.com/gruntwork-io/terratest/modules/test-structure"
 )
 
@@ -22,6 +29,7 @@ const PACKER_VAR_VAULT_DOWNLOAD_URL = "VAULT_DOWNLOAD_URL"
 const PACKER_TEMPLATE_PATH = "../examples/vault-consul-image/vault-consul.json"
 
 const SAVED_TLS_CERT = "TlsCert"
+const SAVED_KEYPAIR = "KeyPair"
 
 // Use Packer to build the Image in the given Packer template, with the given build name and return the Image ID.
 func buildVaultImage(t *testing.T, packerTemplatePath string, packerBuildName string, gcpProjectID string, gcpZone string, tlsCert TlsCert) string {
@@ -48,4 +56,63 @@ func loadTLSCert(t *testing.T, testFolder string) TlsCert {
 	var tlsCert TlsCert
 	test_structure.LoadTestData(t, test_structure.FormatTestDataPath(testFolder, SAVED_TLS_CERT), &tlsCert)
 	return tlsCert
+}
+
+func saveKeyPair(t *testing.T, testFolder string, keyPair *ssh.KeyPair) {
+	test_structure.SaveTestData(t, test_structure.FormatTestDataPath(testFolder, SAVED_KEYPAIR), keyPair)
+}
+
+func loadKeyPair(t *testing.T, testFolder string) ssh.KeyPair {
+	var keyPair ssh.KeyPair
+	test_structure.LoadTestData(t, test_structure.FormatTestDataPath(testFolder, SAVED_KEYPAIR), &keyPair)
+	return keyPair
+}
+
+func getFilesFromInstance(t *testing.T, instance *gcp.Instance, keyPair *ssh.KeyPair, filePaths ...string) map[string]string {
+	publicIp := instance.GetPublicIp(t)
+
+	host := ssh.Host{
+		SshUserName: "terratest",
+		SshKeyPair:  keyPair,
+		Hostname:    publicIp,
+	}
+
+	useSudo := true
+
+	return ssh.FetchContentsOfFiles(t, host, useSudo, filePaths...)
+}
+
+func writeLogFile(t *testing.T, buffer string, destination string) {
+	file, err := os.Create(destination)
+	if err != nil {
+		logger.Logf(t, fmt.Sprintf("Error creating log file on disk: %s", err.Error()))
+	}
+	defer file.Close()
+
+	file.WriteString(buffer)
+}
+
+func addKeyPairToInstancesInGroup(t *testing.T, projectId string, region string, instanceGroupId string, keyPair *ssh.KeyPair, sshUserName string) []*gcp.Instance {
+	instanceGroup := gcp.FetchRegionalInstanceGroup(t, projectId, region, instanceGroupId)
+	instances := getInstancesFromGroup(t, projectId, instanceGroup)
+
+	for _, instance := range instances {
+		instance.AddSshKey(t, sshUserName, keyPair.PublicKey)
+	}
+	return instances
+}
+
+func getInstancesFromGroup(t *testing.T, projectId string, instanceGroup *gcp.RegionalInstanceGroup) []*gcp.Instance {
+	instances := []*gcp.Instance{}
+
+	retry.DoWithRetry(t, "Getting instances", 10, 10*time.Second, func() (string, error) {
+		instances = instanceGroup.GetInstances(t, projectId)
+
+		if len(instances) != 3 {
+			return "", fmt.Errorf("Expected to get three instances, but got %d: %v", len(instances), instances)
+		}
+		return "", nil
+	})
+
+	return instances
 }

--- a/test/terratest_helpers.go
+++ b/test/terratest_helpers.go
@@ -13,11 +13,13 @@ const PACKER_VAR_GCP_PROJECT_ID = "project_id"
 // PACKER_VAR_GCP_ZONE represents the Zone variable in the Packer template
 const PACKER_VAR_GCP_ZONE = "zone"
 
-const PACKER_VAR_CA_PUBLIC_KEY       = "ca_public_key_path"
-const PACKER_VAR_TLS_PUBLIC_KEY      = "tls_public_key_path"
-const PAKCER_VAR_TLS_PRIVATE_KEY     = "tls_private_key_path"
+const PACKER_VAR_CA_PUBLIC_KEY = "ca_public_key_path"
+const PACKER_VAR_TLS_PUBLIC_KEY = "tls_public_key_path"
+const PAKCER_VAR_TLS_PRIVATE_KEY = "tls_private_key_path"
 const PACKER_VAR_CONSUL_DOWNLOAD_URL = "CONSUL_DOWNLOAD_URL"
-const PACKER_VAR_VAULT_DOWNLOAD_URL  = "VAULT_DOWNLOAD_URL"
+const PACKER_VAR_VAULT_DOWNLOAD_URL = "VAULT_DOWNLOAD_URL"
+
+const PACKER_TEMPLATE_PATH = "../examples/vault-consul-image/vault-consul.json"
 
 const SAVED_TLS_CERT = "TlsCert"
 
@@ -29,7 +31,7 @@ func buildVaultImage(t *testing.T, packerTemplatePath string, packerBuildName st
 		Vars: map[string]string{
 			PACKER_VAR_GCP_PROJECT_ID:  gcpProjectID,
 			PACKER_VAR_GCP_ZONE:        gcpZone,
-			PACKER_VAR_CA_PUBLIC_KEY :  tlsCert.CAPublicKeyPath,
+			PACKER_VAR_CA_PUBLIC_KEY:   tlsCert.CAPublicKeyPath,
 			PACKER_VAR_TLS_PUBLIC_KEY:  tlsCert.PublicKeyPath,
 			PAKCER_VAR_TLS_PRIVATE_KEY: tlsCert.PrivateKeyPath,
 		},

--- a/test/vault_cluster_private_test.go
+++ b/test/vault_cluster_private_test.go
@@ -26,6 +26,8 @@ func runVaultPrivateClusterTest(t *testing.T, osName string) {
 	})
 
 	defer test_structure.RunTestStage(t, "log", func() {
+		//ToDo: Modify log retrieval to go through bastion host
+		//      Requires adding feature to terratest
 		//writeVaultLogs(t, "vaultPublicCluster", exampleDir)
 	})
 

--- a/test/vault_cluster_public_test.go
+++ b/test/vault_cluster_public_test.go
@@ -76,7 +76,7 @@ func runVaultPublicClusterTest(t *testing.T, osName string) {
 		saveKeyPair(t, exampleDir, keyPair)
 		addKeyPairToInstancesInGroup(t, projectId, region, instanceGroupId, keyPair, sshUserName)
 
-		cluster := initializeAndUnsealVaultCluster(t, projectId, region, instanceGroupId, sshUserName, keyPair)
+		cluster := initializeAndUnsealVaultCluster(t, projectId, region, instanceGroupId, sshUserName, keyPair, nil)
 		testVault(t, cluster.Leader.Hostname)
 	})
 }

--- a/test/vault_cluster_public_test.go
+++ b/test/vault_cluster_public_test.go
@@ -87,18 +87,20 @@ func testVaultPublicCluster(t *testing.T, osName string) {
 
 		vaultStdOutLogFilePath := "/opt/vault/log/vault-stdout.log"
 		vaultStdErrLogFilePath := "/opt/vault/log/vault-error.log"
+		sysLogFilePath := "/var/log/syslog"
 
 		instanceIdToLogs := map[string]map[string]string{}
 		for _, instance := range instances {
-			instanceId := string(instance.Id)
-			instanceIdToLogs[instanceId] = getFilesFromInstance(t, instance, &keyPair, vaultStdOutLogFilePath, vaultStdErrLogFilePath)
+			instanceName := instance.Name
+			instanceIdToLogs[instanceName] = getFilesFromInstance(t, instance, &keyPair, vaultStdOutLogFilePath, vaultStdErrLogFilePath, sysLogFilePath)
 
-			localDestDir := filepath.Join("/tmp/logs/", "vaultClusterPublic", instanceId)
+			localDestDir := filepath.Join("/tmp/logs/", "vaultClusterPublic", instanceName)
 			if !files.FileExists(localDestDir) {
 				os.MkdirAll(localDestDir, 0755)
 			}
-			writeLogFile(t, instanceIdToLogs[instanceId][vaultStdOutLogFilePath], filepath.Join(localDestDir, "vaultStdOut.log"))
-			writeLogFile(t, instanceIdToLogs[instanceId][vaultStdErrLogFilePath], filepath.Join(localDestDir, "vaultStdErr.log"))
+			writeLogFile(t, instanceIdToLogs[instanceName][vaultStdOutLogFilePath], filepath.Join(localDestDir, "vault-stdout.log"))
+			writeLogFile(t, instanceIdToLogs[instanceName][vaultStdErrLogFilePath], filepath.Join(localDestDir, "vault-error.log"))
+			writeLogFile(t, instanceIdToLogs[instanceName][sysLogFilePath], filepath.Join(localDestDir, "syslog"))
 		}
 	})
 

--- a/test/vault_cluster_public_test.go
+++ b/test/vault_cluster_public_test.go
@@ -143,10 +143,9 @@ func testVaultPublicCluster(t *testing.T, osName string) {
 		sshUserName := "terratest"
 		keyPair := ssh.GenerateRSAKeyPair(t, 2048)
 		saveKeyPair(t, exampleDir, keyPair)
+		addKeyPairToInstancesInGroup(t, projectId, region, instanceGroupId, keyPair, sshUserName)
 
-		instances := addKeyPairToInstancesInGroup(t, projectId, region, instanceGroupId, keyPair, sshUserName)
-
-		initializeAndUnsealVaultCluster(t, projectId, region, instanceGroupId, sshUserName, keyPair)
-		testVault(t, instances[0].GetPublicIp(t))
+		cluster := initializeAndUnsealVaultCluster(t, projectId, region, instanceGroupId, sshUserName, keyPair)
+		testVault(t, cluster.Leader.Hostname)
 	})
 }

--- a/test/vault_helpers.go
+++ b/test/vault_helpers.go
@@ -16,6 +16,8 @@ import (
 	"github.com/hashicorp/vault/api"
 )
 
+const VAULT_PORT = 8200
+
 type VaultCluster struct {
 	Leader     ssh.Host
 	Standby1   ssh.Host
@@ -223,7 +225,7 @@ func testVault(t *testing.T, domainName string) {
 
 	maxRetries := 30
 	sleepBetweenRetries := 10 * time.Second
-	description := fmt.Sprintf("Testing Vault at domain name %s", domainName)
+	description := fmt.Sprintf("Testing Vault at domain name %s and port %d", domainName, VAULT_PORT)
 
 	vaultClient := createVaultClient(t, domainName)
 
@@ -245,9 +247,9 @@ func testVault(t *testing.T, domainName string) {
 // Create a Vault client configured to talk to Vault running at the given domain name
 func createVaultClient(t *testing.T, domainName string) *api.Client {
 	config := api.DefaultConfig()
-	config.Address = fmt.Sprintf("https://%s", domainName)
+	config.Address = fmt.Sprintf("https://%s:%d", domainName, VAULT_PORT)
 
-	// The TLS cert we are using in this test does not have the ELB DNS name in it, so disable the TLS check
+	// The TLS cert we are using in this test does not have the instance DNS name in it, so disable the TLS check
 	clientTLSConfig := config.HttpClient.Transport.(*http.Transport).TLSClientConfig
 	clientTLSConfig.InsecureSkipVerify = true
 

--- a/test/vault_helpers.go
+++ b/test/vault_helpers.go
@@ -1,0 +1,254 @@
+package test
+
+import (
+	"fmt"
+	"github.com/gruntwork-io/terratest/modules/gcp"
+	"github.com/gruntwork-io/terratest/modules/logger"
+	"github.com/gruntwork-io/terratest/modules/retry"
+	"github.com/gruntwork-io/terratest/modules/ssh"
+	"github.com/hashicorp/vault/api"
+	"net/http"
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+type VaultCluster struct {
+	Leader     ssh.Host
+	Standby1   ssh.Host
+	Standby2   ssh.Host
+	UnsealKeys []string
+}
+
+func (c *VaultCluster) GetSshHosts() []ssh.Host {
+	return []ssh.Host{c.Leader, c.Standby1, c.Standby2}
+}
+
+// From: https://www.vaultproject.io/api/system/health.html
+type VaultStatus int
+
+const (
+	Leader        VaultStatus = 200
+	Standby                   = 429
+	Uninitialized             = 501
+	Sealed                    = 503
+)
+
+// Initialize the Vault cluster and unseal each of the nodes by connecting to them over SSH and executing Vault
+// commands. The reason we use SSH rather than using the Vault client remotely is we want to verify that the
+// self-signed TLS certificate is properly configured on each server so when you're on that server, you don't
+// get errors about the certificate being signed by an unknown party.
+// Adapted from https://github.com/hashicorp/terraform-aws-vault/blob/141f57642215820ff758200fe63b3a52d7017061/test/vault_helpers.go#L507
+func initializeAndUnsealVaultCluster(t *testing.T, projectId string, region string, vaultClusterName string, sshUserName string, sshKeyPair *ssh.KeyPair) *VaultCluster {
+	cluster := findVaultClusterNodes(t, projectId, region, vaultClusterName, sshUserName, sshKeyPair)
+
+	verifyCanSsh(t, cluster)
+	assertAllNodesBooted(t, cluster)
+	initializeVault(t, cluster)
+
+	assertNodeStatus(t, cluster.Leader, Sealed)
+	unsealNode(t, cluster.Leader, cluster.UnsealKeys)
+	assertNodeStatus(t, cluster.Leader, Leader)
+
+	assertNodeStatus(t, cluster.Standby1, Sealed)
+	unsealNode(t, cluster.Standby1, cluster.UnsealKeys)
+	assertNodeStatus(t, cluster.Standby1, Standby)
+
+	assertNodeStatus(t, cluster.Standby2, Sealed)
+	unsealNode(t, cluster.Standby2, cluster.UnsealKeys)
+	assertNodeStatus(t, cluster.Standby2, Standby)
+
+	return cluster
+}
+
+// Find the nodes in the given Vault Instance Group and return them in a VaultCluster struct
+func findVaultClusterNodes(t *testing.T, projectId string, region string, vaultClusterName string, sshUserName string, sshKeyPair *ssh.KeyPair) *VaultCluster {
+	vaultInstanceGroup := gcp.FetchRegionalInstanceGroup(t, projectId, region, vaultClusterName)
+	publicIps := vaultInstanceGroup.GetPublicIps(t, projectId)
+
+	if len(publicIps) != 3 {
+		t.Fatalf("Expected to get three IP addresses for Vault cluster, but got %d: %v", len(publicIps), publicIps)
+	}
+
+	return &VaultCluster{
+		Leader: ssh.Host{
+			Hostname:    publicIps[0],
+			SshUserName: sshUserName,
+			SshKeyPair:  sshKeyPair,
+		},
+
+		Standby1: ssh.Host{
+			Hostname:    publicIps[1],
+			SshUserName: sshUserName,
+			SshKeyPair:  sshKeyPair,
+		},
+
+		Standby2: ssh.Host{
+			Hostname:    publicIps[2],
+			SshUserName: sshUserName,
+			SshKeyPair:  sshKeyPair,
+		},
+	}
+}
+
+// Wait until we can connect to each of the Vault cluster EC2 Instances
+func verifyCanSsh(t *testing.T, cluster *VaultCluster) {
+	for _, host := range cluster.GetSshHosts() {
+		if host.Hostname != "" {
+
+			maxRetries := 30
+			sleepBetweenRetries := 10 * time.Second
+			description := fmt.Sprintf("Attempting SSH connection to %s\n", host.Hostname)
+
+			retry.DoWithRetry(t, description, maxRetries, sleepBetweenRetries, func() (string, error) {
+				return "", ssh.CheckSshConnectionE(t, host)
+			})
+		}
+	}
+}
+
+// Wait until the Vault servers are booted the very first time on the Compute Instances. As a simple solution, we simply
+// wait for the leader to boot and assume if it's up, the other nodes will be, too.
+func assertAllNodesBooted(t *testing.T, cluster *VaultCluster) {
+	for _, node := range cluster.GetSshHosts() {
+		if node.Hostname != "" {
+			logger.Logf(t, "Waiting for Vault to boot the first time on host %s. Expecting it to be in uninitialized status (%d).", node.Hostname, int(Uninitialized))
+			assertNodeStatus(t, node, Uninitialized)
+		}
+	}
+}
+
+// Initialize the Vault cluster, filling in the unseal keys in the given vaultCluster struct
+func initializeVault(t *testing.T, vaultCluster *VaultCluster) {
+	logger.Logf(t, "Initializing the cluster")
+	output := ssh.CheckSshCommand(t, vaultCluster.Leader, "vault operator init")
+	vaultCluster.UnsealKeys = parseUnsealKeysFromVaultInitResponse(t, output)
+}
+
+// Unseal the given Vault host using the given unseal keys
+func unsealNode(t *testing.T, host ssh.Host, unsealKeys []string) {
+	unsealCommands := []string{}
+	for _, unsealKey := range unsealKeys {
+		unsealCommands = append(unsealCommands, fmt.Sprintf("vault operator unseal %s", unsealKey))
+	}
+
+	unsealCommand := strings.Join(unsealCommands, " && ")
+
+	logger.Logf(t, "Unsealing Vault on host %s", host.Hostname)
+	ssh.CheckSshCommand(t, host, unsealCommand)
+}
+
+// Parse an unseal key from a single line of the stdout of the vault init command, which should be of the format:
+//
+// Unseal Key 1: Gi9xAX9rFfmHtSi68mYOh0H3H2eu8E77nvRm/0fsuwQB
+func parseUnsealKey(t *testing.T, str string) string {
+	UnsealKeyRegex := regexp.MustCompile("^Unseal Key \\d: (.+)$")
+	matches := UnsealKeyRegex.FindStringSubmatch(str)
+	if len(matches) != 2 {
+		t.Fatalf("Unexpected format for unseal key: %s", str)
+	}
+	return matches[1]
+}
+
+// Parse the unseal keys from the stdout returned from the vault init command.
+//
+// The format we're expecting is:
+//
+// Unseal Key 1: Gi9xAX9rFfmHtSi68mYOh0H3H2eu8E77nvRm/0fsuwQB
+// Unseal Key 2: ecQjHmaXc79GtwJN/hYWd/N2skhoNgyCmgCfGqRMTPIC
+// Unseal Key 3: LEOa/DdZDgLHBqK0JoxbviKByUAgxfm2dwK4y1PX6qED
+// Unseal Key 4: ZY87ijsj9/f5fO7ufgr4yhPWU/2ZZM3BGuSQRDFZpwoE
+// Unseal Key 5: MAiCaGrtikp4zU4XppC1A8IhKPXRlzj19+a3lcbCAVkF
+func parseUnsealKeysFromVaultInitResponse(t *testing.T, vaultInitResponse string) []string {
+	lines := strings.Split(vaultInitResponse, "\n")
+	if len(lines) < 3 {
+		t.Fatalf("Did not find at least three lines of in the vault init stdout: %s", vaultInitResponse)
+	}
+
+	// By default, Vault requires 3 unseal keys out of 5, so just parse those first three
+	unsealKey1 := parseUnsealKey(t, lines[0])
+	unsealKey2 := parseUnsealKey(t, lines[1])
+	unsealKey3 := parseUnsealKey(t, lines[2])
+
+	return []string{unsealKey1, unsealKey2, unsealKey3}
+}
+
+// Check that the given Vault node has the given status
+func assertNodeStatus(t *testing.T, host ssh.Host, expectedStatus VaultStatus) {
+
+	maxRetries := 30
+	sleepBetweenRetries := 10 * time.Second
+	description := fmt.Sprintf("Check that the Vault node %s has status %d", host.Hostname, int(expectedStatus))
+
+	out := retry.DoWithRetry(t, description, maxRetries, sleepBetweenRetries, func() (string, error) {
+		return checkStatus(t, host, expectedStatus)
+	})
+
+	logger.Logf(t, out)
+}
+
+// Check the status of the given Vault node and ensure it matches the expected status. Note that we use curl to do the
+// status check so we can ensure that TLS certificates work for curl (and not just the Vault client).
+func checkStatus(t *testing.T, host ssh.Host, expectedStatus VaultStatus) (string, error) {
+	curlCommand := "curl -s -o /dev/null -w '%{http_code}' https://127.0.0.1:8200/v1/sys/health"
+	logger.Logf(t, "Using curl to check status of Vault server %s: %s", host.Hostname, curlCommand)
+
+	output, err := ssh.CheckSshCommandE(t, host, curlCommand)
+	if err != nil {
+		return "", err
+	}
+	status, err := strconv.Atoi(output)
+	if err != nil {
+		return "", err
+	}
+
+	if status == int(expectedStatus) {
+		return fmt.Sprintf("Got expected status code %d", status), nil
+	} else {
+		return "", fmt.Errorf("Expected status code %d for host %s, but got %d", int(expectedStatus), host.Hostname, status)
+	}
+}
+
+// Use the Vault client to connect to the Vault cluster via the public DNS entry, and make sure it works without
+// Vault or TLS errors
+func testVault(t *testing.T, domainName string) {
+
+	maxRetries := 30
+	sleepBetweenRetries := 10 * time.Second
+	description := fmt.Sprintf("Testing Vault at domain name %s", domainName)
+
+	vaultClient := createVaultClient(t, domainName)
+
+	out := retry.DoWithRetry(t, description, maxRetries, sleepBetweenRetries, func() (string, error) {
+		isInitialized, err := vaultClient.Sys().InitStatus()
+		if err != nil {
+			return "", err
+		}
+		if isInitialized {
+			return "Successfully verified that Vault cluster is initialized!", nil
+		} else {
+			return "", fmt.Errorf("expected Vault cluster to be initialized, but it is not")
+		}
+	})
+
+	logger.Logf(t, out)
+}
+
+// Create a Vault client configured to talk to Vault running at the given domain name
+func createVaultClient(t *testing.T, domainName string) *api.Client {
+	config := api.DefaultConfig()
+	config.Address = fmt.Sprintf("https://%s", domainName)
+
+	// The TLS cert we are using in this test does not have the ELB DNS name in it, so disable the TLS check
+	clientTLSConfig := config.HttpClient.Transport.(*http.Transport).TLSClientConfig
+	clientTLSConfig.InsecureSkipVerify = true
+
+	client, err := api.NewClient(config)
+	if err != nil {
+		t.Fatalf("Failed to create Vault client: %v", err)
+	}
+
+	return client
+}

--- a/test/vault_helpers.go
+++ b/test/vault_helpers.go
@@ -2,17 +2,18 @@ package test
 
 import (
 	"fmt"
-	"github.com/gruntwork-io/terratest/modules/gcp"
-	"github.com/gruntwork-io/terratest/modules/logger"
-	"github.com/gruntwork-io/terratest/modules/retry"
-	"github.com/gruntwork-io/terratest/modules/ssh"
-	"github.com/hashicorp/vault/api"
 	"net/http"
 	"regexp"
 	"strconv"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/gruntwork-io/terratest/modules/gcp"
+	"github.com/gruntwork-io/terratest/modules/logger"
+	"github.com/gruntwork-io/terratest/modules/retry"
+	"github.com/gruntwork-io/terratest/modules/ssh"
+	"github.com/hashicorp/vault/api"
 )
 
 type VaultCluster struct {

--- a/test/vault_helpers.go
+++ b/test/vault_helpers.go
@@ -273,6 +273,29 @@ func createVaultClient(t *testing.T, domainName string) *api.Client {
 	return client
 }
 
+// SSH to a Vault node and make sure that is properly configured to use Consul for DNS so that the vault.service.consul
+// domain name works.
+func testVaultUsesConsulForDns(t *testing.T, cluster *VaultCluster) {
+	// Pick any host, it shouldn't matter
+	host := cluster.Standby1
+
+	command := "vault status -address=https://vault.service.consul:8200"
+	description := fmt.Sprintf("Checking that the Vault server at %s is properly configured to use Consul for DNS: %s", host.Hostname, command)
+	logger.Logf(t, description)
+
+	maxRetries := 30
+	sleepBetweenRetries := 10 * time.Second
+
+	out, err := retry.DoWithRetryE(t, description, maxRetries, sleepBetweenRetries, func() (string, error) {
+		return ssh.CheckSshCommandE(t, host, command)
+	})
+
+	logger.Logf(t, "Output from command vault status call to vault.service.consul: %s", out)
+	if err != nil {
+		t.Fatalf("Failed to run vault command with vault.service.consul URL due to error: %v", err)
+	}
+}
+
 // Gets Vault logs and syslog written to disk, so it is exposed on circle ci artifacts
 func writeVaultLogs(t *testing.T, testName string, testDir string) {
 	terraformOptions := test_structure.LoadTerraformOptions(t, testDir)

--- a/test/vault_helpers.go
+++ b/test/vault_helpers.go
@@ -42,8 +42,8 @@ const (
 // self-signed TLS certificate is properly configured on each server so when you're on that server, you don't
 // get errors about the certificate being signed by an unknown party.
 // Adapted from https://github.com/hashicorp/terraform-aws-vault/blob/141f57642215820ff758200fe63b3a52d7017061/test/vault_helpers.go#L507
-func initializeAndUnsealVaultCluster(t *testing.T, projectId string, region string, vaultClusterName string, sshUserName string, sshKeyPair *ssh.KeyPair) *VaultCluster {
-	cluster := findVaultClusterNodes(t, projectId, region, vaultClusterName, sshUserName, sshKeyPair)
+func initializeAndUnsealVaultCluster(t *testing.T, projectId string, region string, instanceGroupId string, sshUserName string, sshKeyPair *ssh.KeyPair) *VaultCluster {
+	cluster := findVaultClusterNodes(t, projectId, region, instanceGroupId, sshUserName, sshKeyPair)
 
 	verifyCanSsh(t, cluster)
 	assertAllNodesBooted(t, cluster)
@@ -65,10 +65,10 @@ func initializeAndUnsealVaultCluster(t *testing.T, projectId string, region stri
 }
 
 // Find the nodes in the given Vault Instance Group and return them in a VaultCluster struct
-func findVaultClusterNodes(t *testing.T, projectId string, region string, vaultClusterName string, sshUserName string, sshKeyPair *ssh.KeyPair) *VaultCluster {
-	vaultInstanceGroup := gcp.FetchRegionalInstanceGroup(t, projectId, region, vaultClusterName)
-	publicIps := vaultInstanceGroup.GetPublicIps(t, projectId)
+func findVaultClusterNodes(t *testing.T, projectId string, region string, instanceGroupId string, sshUserName string, sshKeyPair *ssh.KeyPair) *VaultCluster {
+	vaultInstanceGroup := gcp.FetchRegionalInstanceGroup(t, projectId, region, instanceGroupId)
 
+	publicIps := vaultInstanceGroup.GetPublicIps(t, projectId)
 	if len(publicIps) != 3 {
 		t.Fatalf("Expected to get three IP addresses for Vault cluster, but got %d: %v", len(publicIps), publicIps)
 	}

--- a/test/vault_helpers.go
+++ b/test/vault_helpers.go
@@ -281,8 +281,8 @@ func writeVaultLogs(t *testing.T, testName string, testDir string) {
 	projectId := test_structure.LoadString(t, WORK_DIR, SAVED_GCP_PROJECT_ID)
 	region := test_structure.LoadString(t, WORK_DIR, SAVED_GCP_REGION_NAME)
 	instanceGroupId := terraform.OutputRequired(t, terraformOptions, TFOUT_INSTANCE_GROUP_ID)
-	instanceGroup := gcp.FetchRegionalInstanceGroup(t, testDir, region, instanceGroupId)
-	instances := instanceGroup.GetInstances(t, projectId)
+	instanceGroup := gcp.FetchRegionalInstanceGroup(t, projectId, region, instanceGroupId)
+	instances := getInstancesFromGroup(t, projectId, instanceGroup)
 
 	vaultStdOutLogFilePath := "/opt/vault/log/vault-stdout.log"
 	vaultStdErrLogFilePath := "/opt/vault/log/vault-error.log"

--- a/test/vault_main_test.go
+++ b/test/vault_main_test.go
@@ -1,0 +1,62 @@
+package test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/test-structure"
+)
+
+const IMAGE_EXAMPLE_PATH = "../examples/vault-consul-ami/vault-consul.json"
+const WORK_DIR = "./"
+const PACKER_BUILD_NAME = "ubuntu-16"
+
+type testCase struct {
+	Name string                   // Name of the test
+	Func func(*testing.T, string) // Function that runs test. Receives(t, packerOsName)
+}
+
+var testCases = []testCase{
+	{
+		"TestVaultPrivateCluster",
+		runVaultPrivateClusterTest,
+	},
+	{
+		"TestVaultPublicCluster",
+		runVaultPublicClusterTest,
+	},
+}
+
+func TestMainVaultCluster(t *testing.T) {
+	t.Parallel()
+
+	test_structure.RunTestStage(t, "setup_image", func() {
+		buildVaultImage(t, PACKER_BUILD_NAME, WORK_DIR)
+	})
+
+	defer test_structure.RunTestStage(t, "delete_image", func() {
+		deleteVaultImage(t, WORK_DIR)
+	})
+
+	t.Run("group", func(t *testing.T) {
+		runAllTests(t)
+	})
+
+}
+
+func runAllTests(t *testing.T) {
+	for _, testCase := range testCases {
+		// This re-assignment necessary, because the variable testCase is defined and set outside the forloop.
+		// As such, it gets overwritten on each iteration of the forloop. This is fine if you don't have concurrent code in the loop,
+		// but in this case, because you have a t.Parallel, the t.Run completes before the test function exits,
+		// which means that the value of testCase might change.
+		// More information at:
+		// "Be Careful with Table Driven Tests and t.Parallel()"
+		// https://gist.github.com/posener/92a55c4cd441fc5e5e85f27bca008721
+		testCase := testCase
+		t.Run(fmt.Sprintf("%sWithUbuntu", testCase.Name), func(t *testing.T) {
+			t.Parallel()
+			testCase.Func(t, PACKER_BUILD_NAME)
+		})
+	}
+}


### PR DESCRIPTION
* Finishes implementation of tests for public cluster
* Fixes a few issues with generating image and parts of the tests that needed a retry
* Adds a bastion host to private cluster and adapts tests to go through bastion host
* Fixes private cluster. Vault was not booting because consul was not able to join the cluster. This was happening because since the cluster is private, it didn't have internet access to request cluster info. This was fixed by creating a subnet that authorizes internal calls to the google api even without internet.
* Validates private cluster

Future todos:
* Add artifacts logs from private cluster to circle ci. This requires implementing a function on terratest that grabs the logs through a bastion host.
* Update terratest version when applicable 
