### PR TITLE
Add image_project_id variable

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -33,8 +33,9 @@ module "vault_cluster" {
   cluster_tag_name = "${var.vault_cluster_name}"
   machine_type     = "${var.vault_cluster_machine_type}"
 
-  source_image   = "${var.vault_source_image}"
-  startup_script = "${data.template_file.startup_script_vault.rendered}"
+  image_project_id = "${var.image_project_id}"
+  source_image     = "${var.vault_source_image}"
+  startup_script   = "${data.template_file.startup_script_vault.rendered}"
 
   gcs_bucket_name          = "${var.vault_cluster_name}"
   gcs_bucket_location      = "${var.gcs_bucket_location}"

--- a/modules/vault-cluster/main.tf
+++ b/modules/vault-cluster/main.tf
@@ -290,5 +290,6 @@ data "template_file" "compute_instance_template_self_link" {
 # This is a workaround for a provider bug in Terraform v0.11.8. For more information please refer to:
 # https://github.com/terraform-providers/terraform-provider-google/issues/2067.
 data "google_compute_image" "image" {
-  name = "${var.source_image}"
+  name    = "${var.source_image}"
+  project = "${var.image_project_id != "" ? var.image_project_id : var.gcp_project_id}"
 }

--- a/modules/vault-cluster/variables.tf
+++ b/modules/vault-cluster/variables.tf
@@ -164,6 +164,11 @@ variable "root_volume_disk_type" {
   default     = "pd-standard"
 }
 
+variable "image_project_id" {
+  description = "The name of the GCP Project where the image is located. Useful when using a separate project for custom images. If empty, var.gcp_project_id will be used."
+  default     = ""
+}
+
 # Google Storage Bucket Settings
 
 variable "gcs_bucket_force_destroy" {

--- a/variables.tf
+++ b/variables.tf
@@ -91,3 +91,8 @@ variable "enable_vault_ui" {
   description = "If true, enable the Vault UI"
   default     = true
 }
+
+variable "image_project_id" {
+  description = "The name of the GCP Project where the image is located. Useful when using a separate project for custom images. If empty, var.gcp_project_id will be used."
+  default     = ""
+}


### PR DESCRIPTION
Adds an image_project_id variable which allows for the use of a Compute Images from outside the default project. Mostly copied from https://github.com/hashicorp/terraform-google-consul/pull/34.

Let me know if there are any issues.