### PR TITLE
Fix tests

### DIFF
--- a/examples/vault-cluster-enterprise/outputs.tf
+++ b/examples/vault-cluster-enterprise/outputs.tf
@@ -22,6 +22,10 @@ output "instance_group_id" {
   value = "${module.vault_cluster.instance_group_id}"
 }
 
+output "instance_group_name" {
+  value = "${module.vault_cluster.instance_group_name}"
+}
+
 output "instance_group_url" {
   value = "${module.vault_cluster.instance_group_url}"
 }

--- a/examples/vault-cluster-private-with-public-lb/outputs.tf
+++ b/examples/vault-cluster-private-with-public-lb/outputs.tf
@@ -18,6 +18,10 @@ output "instance_group_id" {
   value = "${module.vault_cluster.instance_group_id}"
 }
 
+output "instance_group_name" {
+  value = "${module.vault_cluster.instance_group_name}"
+}
+
 output "instance_group_url" {
   value = "${module.vault_cluster.instance_group_url}"
 }

--- a/examples/vault-cluster-private/outputs.tf
+++ b/examples/vault-cluster-private/outputs.tf
@@ -22,6 +22,10 @@ output "instance_group_id" {
   value = "${module.vault_cluster.instance_group_id}"
 }
 
+output "instance_group_name" {
+  value = "${module.vault_cluster.instance_group_name}"
+}
+
 output "instance_group_url" {
   value = "${module.vault_cluster.instance_group_url}"
 }

--- a/modules/vault-cluster/outputs.tf
+++ b/modules/vault-cluster/outputs.tf
@@ -6,6 +6,10 @@ output "instance_group_id" {
   value = "${google_compute_region_instance_group_manager.vault.id}"
 }
 
+output "instance_group_name" {
+  value = "${google_compute_region_instance_group_manager.vault.name}"
+}
+
 output "cluster_service_account" {
   value = "${local.service_account_email}"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -14,6 +14,10 @@ output "instance_group_id" {
   value = "${module.vault_cluster.instance_group_id}"
 }
 
+output "instance_group_name" {
+  value = "${module.vault_cluster.instance_group_name}"
+}
+
 output "instance_group_url" {
   value = "${module.vault_cluster.instance_group_url}"
 }

--- a/test/terratest_helpers.go
+++ b/test/terratest_helpers.go
@@ -122,8 +122,8 @@ func writeLogFile(t *testing.T, buffer string, destination string) {
 	file.WriteString(buffer)
 }
 
-func addKeyPairToInstancesInGroup(t *testing.T, projectId string, region string, instanceGroupId string, keyPair *ssh.KeyPair, sshUserName string, expectedInstances int) []*gcp.Instance {
-	instanceGroup := gcp.FetchRegionalInstanceGroup(t, projectId, region, instanceGroupId)
+func addKeyPairToInstancesInGroup(t *testing.T, projectId string, region string, instanceGroupName string, keyPair *ssh.KeyPair, sshUserName string, expectedInstances int) []*gcp.Instance {
+	instanceGroup := gcp.FetchRegionalInstanceGroup(t, projectId, region, instanceGroupName)
 	instances := getInstancesFromGroup(t, projectId, instanceGroup, expectedInstances)
 
 	for _, instance := range instances {

--- a/test/vault_cluster_enterprise_test.go
+++ b/test/vault_cluster_enterprise_test.go
@@ -89,12 +89,12 @@ func runVaultEnterpriseClusterTest(t *testing.T) {
 		terraformOptions := test_structure.LoadTerraformOptions(t, exampleDir)
 		projectId := test_structure.LoadString(t, WORK_DIR, SAVED_GCP_PROJECT_ID)
 		region := test_structure.LoadString(t, WORK_DIR, SAVED_GCP_REGION_NAME)
-		instanceGroupId := terraform.OutputRequired(t, terraformOptions, TFOUT_INSTANCE_GROUP_ID)
+		instanceGroupName := terraform.OutputRequired(t, terraformOptions, TFOUT_INSTANCE_GROUP_NAME)
 
 		sshUserName := "terratest"
 		keyPair := ssh.GenerateRSAKeyPair(t, 2048)
 		saveKeyPair(t, exampleDir, keyPair)
-		addKeyPairToInstancesInGroup(t, projectId, region, instanceGroupId, keyPair, sshUserName, 3)
+		addKeyPairToInstancesInGroup(t, projectId, region, instanceGroupName, keyPair, sshUserName, 3)
 
 		bastionName := terraform.OutputRequired(t, terraformOptions, TFVAR_NAME_BASTION_SERVER_NAME)
 		bastionInstance := gcp.FetchInstance(t, projectId, bastionName)
@@ -105,13 +105,13 @@ func runVaultEnterpriseClusterTest(t *testing.T) {
 			SshKeyPair:  keyPair,
 		}
 
-		cluster := testVaultInitializeAutoUnseal(t, projectId, region, instanceGroupId, sshUserName, keyPair, &bastionHost)
+		cluster := testVaultInitializeAutoUnseal(t, projectId, region, instanceGroupName, sshUserName, keyPair, &bastionHost)
 		testVaultUsesConsulForDns(t, cluster, &bastionHost)
 	})
 }
 
-func testVaultInitializeAutoUnseal(t *testing.T, projectId string, region string, instanceGroupId string, sshUserName string, sshKeyPair *ssh.KeyPair, bastionHost *ssh.Host) *VaultCluster {
-	cluster := findVaultClusterNodes(t, projectId, region, instanceGroupId, sshUserName, sshKeyPair, bastionHost)
+func testVaultInitializeAutoUnseal(t *testing.T, projectId string, region string, instanceGroupName string, sshUserName string, sshKeyPair *ssh.KeyPair, bastionHost *ssh.Host) *VaultCluster {
+	cluster := findVaultClusterNodes(t, projectId, region, instanceGroupName, sshUserName, sshKeyPair, bastionHost)
 
 	verifyCanSsh(t, cluster, bastionHost)
 	testVaultIsEnterprise(t, cluster.Leader, bastionHost)

--- a/test/vault_cluster_private_test.go
+++ b/test/vault_cluster_private_test.go
@@ -67,12 +67,12 @@ func runVaultPrivateClusterTest(t *testing.T) {
 		terraformOptions := test_structure.LoadTerraformOptions(t, exampleDir)
 		projectId := test_structure.LoadString(t, WORK_DIR, SAVED_GCP_PROJECT_ID)
 		region := test_structure.LoadString(t, WORK_DIR, SAVED_GCP_REGION_NAME)
-		instanceGroupId := terraform.OutputRequired(t, terraformOptions, TFOUT_INSTANCE_GROUP_ID)
+		instanceGroupName := terraform.OutputRequired(t, terraformOptions, TFOUT_INSTANCE_GROUP_NAME)
 
 		sshUserName := "terratest"
 		keyPair := ssh.GenerateRSAKeyPair(t, 2048)
 		saveKeyPair(t, exampleDir, keyPair)
-		addKeyPairToInstancesInGroup(t, projectId, region, instanceGroupId, keyPair, sshUserName, 3)
+		addKeyPairToInstancesInGroup(t, projectId, region, instanceGroupName, keyPair, sshUserName, 3)
 
 		bastionName := terraform.OutputRequired(t, terraformOptions, TFVAR_NAME_BASTION_SERVER_NAME)
 		bastionInstance := gcp.FetchInstance(t, projectId, bastionName)
@@ -83,7 +83,7 @@ func runVaultPrivateClusterTest(t *testing.T) {
 			SshKeyPair:  keyPair,
 		}
 
-		cluster := initializeAndUnsealVaultCluster(t, projectId, region, instanceGroupId, sshUserName, keyPair, &bastionHost)
+		cluster := initializeAndUnsealVaultCluster(t, projectId, region, instanceGroupName, sshUserName, keyPair, &bastionHost)
 		testVaultUsesConsulForDns(t, cluster, &bastionHost)
 	})
 }

--- a/test/vault_cluster_public_test.go
+++ b/test/vault_cluster_public_test.go
@@ -69,14 +69,14 @@ func runVaultPublicClusterTest(t *testing.T) {
 		terraformOptions := test_structure.LoadTerraformOptions(t, exampleDir)
 		projectId := test_structure.LoadString(t, WORK_DIR, SAVED_GCP_PROJECT_ID)
 		region := test_structure.LoadString(t, WORK_DIR, SAVED_GCP_REGION_NAME)
-		instanceGroupId := terraform.OutputRequired(t, terraformOptions, TFOUT_INSTANCE_GROUP_ID)
+		instanceGroupName := terraform.OutputRequired(t, terraformOptions, TFOUT_INSTANCE_GROUP_NAME)
 
 		sshUserName := "terratest"
 		keyPair := ssh.GenerateRSAKeyPair(t, 2048)
 		saveKeyPair(t, exampleDir, keyPair)
-		addKeyPairToInstancesInGroup(t, projectId, region, instanceGroupId, keyPair, sshUserName, 3)
+		addKeyPairToInstancesInGroup(t, projectId, region, instanceGroupName, keyPair, sshUserName, 3)
 
-		cluster := initializeAndUnsealVaultCluster(t, projectId, region, instanceGroupId, sshUserName, keyPair, nil)
+		cluster := initializeAndUnsealVaultCluster(t, projectId, region, instanceGroupName, sshUserName, keyPair, nil)
 		testVault(t, cluster.Leader.Hostname)
 	})
 }

--- a/test/vault_helpers.go
+++ b/test/vault_helpers.go
@@ -25,7 +25,7 @@ const LOGS_STORAGE_PATH = "/tmp/logs/"
 const VAULT_PORT = 8200
 
 // Terraform Outputs
-const TFOUT_INSTANCE_GROUP_ID = "instance_group_id"
+const TFOUT_INSTANCE_GROUP_NAME = "instance_group_name"
 
 type VaultCluster struct {
 	Leader     ssh.Host
@@ -53,8 +53,8 @@ const (
 // self-signed TLS certificate is properly configured on each server so when you're on that server, you don't
 // get errors about the certificate being signed by an unknown party.
 // Adapted from https://github.com/hashicorp/terraform-aws-vault/blob/141f57642215820ff758200fe63b3a52d7017061/test/vault_helpers.go#L507
-func initializeAndUnsealVaultCluster(t *testing.T, projectId string, region string, instanceGroupId string, sshUserName string, sshKeyPair *ssh.KeyPair, bastionHost *ssh.Host) *VaultCluster {
-	cluster := findVaultClusterNodes(t, projectId, region, instanceGroupId, sshUserName, sshKeyPair, bastionHost)
+func initializeAndUnsealVaultCluster(t *testing.T, projectId string, region string, instanceGroupName string, sshUserName string, sshKeyPair *ssh.KeyPair, bastionHost *ssh.Host) *VaultCluster {
+	cluster := findVaultClusterNodes(t, projectId, region, instanceGroupName, sshUserName, sshKeyPair, bastionHost)
 
 	verifyCanSsh(t, cluster, bastionHost)
 	assertAllNodesBooted(t, cluster, bastionHost)
@@ -77,8 +77,8 @@ func initializeAndUnsealVaultCluster(t *testing.T, projectId string, region stri
 }
 
 // Find the nodes in the given Vault Instance Group and return them in a VaultCluster struct
-func findVaultClusterNodes(t *testing.T, projectId string, region string, instanceGroupId string, sshUserName string, sshKeyPair *ssh.KeyPair, bastionHost *ssh.Host) *VaultCluster {
-	vaultInstanceGroup := gcp.FetchRegionalInstanceGroup(t, projectId, region, instanceGroupId)
+func findVaultClusterNodes(t *testing.T, projectId string, region string, instanceGroupName string, sshUserName string, sshKeyPair *ssh.KeyPair, bastionHost *ssh.Host) *VaultCluster {
+	vaultInstanceGroup := gcp.FetchRegionalInstanceGroup(t, projectId, region, instanceGroupName)
 	hostnames := getClusterHostnames(t, projectId, vaultInstanceGroup, bastionHost)
 
 	return &VaultCluster{
@@ -317,8 +317,8 @@ func writeVaultLogs(t *testing.T, testName string, testDir string) {
 	keyPair := loadKeyPair(t, testDir)
 	projectId := test_structure.LoadString(t, WORK_DIR, SAVED_GCP_PROJECT_ID)
 	region := test_structure.LoadString(t, WORK_DIR, SAVED_GCP_REGION_NAME)
-	instanceGroupId := terraform.OutputRequired(t, terraformOptions, TFOUT_INSTANCE_GROUP_ID)
-	instanceGroup := gcp.FetchRegionalInstanceGroup(t, projectId, region, instanceGroupId)
+	instanceGroupName := terraform.OutputRequired(t, terraformOptions, TFOUT_INSTANCE_GROUP_NAME)
+	instanceGroup := gcp.FetchRegionalInstanceGroup(t, projectId, region, instanceGroupName)
 	instances := getInstancesFromGroup(t, projectId, instanceGroup, 3)
 
 	vaultStdOutLogFilePath := "/opt/vault/log/vault-stdout.log"

--- a/test/vault_main_test.go
+++ b/test/vault_main_test.go
@@ -57,7 +57,8 @@ func TestMainVaultCluster(t *testing.T) {
 		vaultDownloadUrl := getUrlFromEnv(t, "VAULT_PACKER_TEMPLATE_VAR_VAULT_DOWNLOAD_URL")
 
 		projectId := gcp.GetGoogleProjectIDFromEnvVar(t)
-		region := gcp.GetRandomRegion(t, projectId, nil, nil)
+		// These three regions have a low limit quota of In-use IP addresses which fail the tests
+		region := gcp.GetRandomRegion(t, projectId, nil, []string{"asia-northeast2", "europe-west3", "europe-west6"})
 		zone := gcp.GetRandomZoneForRegion(t, projectId, region)
 
 		test_structure.SaveString(t, WORK_DIR, SAVED_GCP_PROJECT_ID, projectId)


### PR DESCRIPTION
Before upgrading to terraform 0.12 I noticed tests were failing on master. Not sure if the culprit was an update in the api or the provider, but currently `gcp.FetchRegionalInstanceGroup` does not take an instance group id, but an instance group name, and a regex check was failing.

Also added some regions to the forbidden region list as they have very low limits of ip address in use quota. I requested a raise in these quotas, but it is not immediate