### PR TITLE
Updated a variable name on private with lb example

### DIFF
--- a/examples/vault-cluster-private-with-public-lb/main.tf
+++ b/examples/vault-cluster-private-with-public-lb/main.tf
@@ -24,7 +24,7 @@ module "vault_cluster" {
   # source = "git::git@github.com:hashicorp/terraform-google-vault.git//modules/vault-cluster?ref=v0.0.1"
   source = "../../modules/vault-cluster"
 
-  gcp_project_id = var.gcp_project_id
+  gcp_project_id = var.gcp_project
   gcp_region     = var.gcp_region
 
   cluster_name     = var.vault_cluster_name


### PR DESCRIPTION
Was referencing a nonexistent variable to pass to the consul module. Changed to the right variable name - gcp_project instead of gcp_project_id.