### PR TITLE
Updated the bastion server to use a newer image

### DIFF
--- a/examples/vault-cluster-private/main.tf
+++ b/examples/vault-cluster-private/main.tf
@@ -46,7 +46,7 @@ resource "google_compute_instance" "bastion" {
 
   boot_disk {
     initialize_params {
-      image = "ubuntu-1810-cosmic-v20181114"
+      image = "ubuntu-2004-focal-v20200907"
     }
   }
 


### PR DESCRIPTION
Use of the current image is causing the issue - 

`The resource 'projects/ubuntu-os-cloud/global/images/ubuntu-1810-cosmic-v20181114' is obsolete.  New uses are not allowed.  No replacement was specified.`

Upgraded it to a newer image - ubuntu-2004-focal-v20200907