### PR TITLE
Use docker mirror

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ workspace_root: &workspace_root
 defaults: &defaults
   working_directory: *workspace_root
   docker:
-  - image: gruntwork/circle-ci-test-image-base:go1.11
+  - image: docker.mirror.hashicorp.services/gruntwork/circle-ci-test-image-base:go1.11
 
 version: 2
 jobs:


### PR DESCRIPTION
CHANGELOG: no impact

Dockerhub is going to rate limit unauthenticated pulls on November 1st. IPs from CI machines will be near their limit all the time. We're moving projects to use a public un-rate-limited Mirror of these images instead. Let me know if you have any q's, otherwise feel free to merge when you can! 
