### PR TITLE
Update the script for google provider 2.0.0

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -77,7 +77,7 @@ data "template_file" "startup_script_vault" {
 # ---------------------------------------------------------------------------------------------------------------------
 
 module "consul_cluster" {
-  source = "git::git@github.com:hashicorp/terraform-google-consul.git//modules/consul-cluster?ref=v0.4.0"
+  source = "github.com/teradici/terraform-google-consul//modules/consul-cluster?ref=v0.5.0"
 
   gcp_project_id = var.gcp_project_id
   gcp_region     = var.gcp_region

--- a/modules/vault-cluster/main.tf
+++ b/modules/vault-cluster/main.tf
@@ -57,13 +57,20 @@ resource "google_compute_region_instance_group_manager" "vault" {
   project = var.gcp_project_id
 
   base_instance_name = var.cluster_name
-  instance_template  = data.template_file.compute_instance_template_self_link.rendered
+
+  version {
+    instance_template  = data.template_file.compute_instance_template_self_link.rendered
+  }
+
   region             = var.gcp_region
 
   # Restarting a Vault server has an important consequence: The Vault server has to be manually unsealed again. Therefore,
   # the update strategy used to roll out a new GCE Instance Template must be a rolling update. But since Terraform does
   # not yet support ROLLING_UPDATE, such updates must be manually rolled out for now.
-  update_strategy = var.instance_group_update_strategy
+  # Invalid after google provider 2.0.0
+  # may consider to use update_policy if needed.
+  # https://registry.terraform.io/providers/hashicorp/google/latest/docs/guides/version_2_upgrade
+  # update_strategy = var.instance_group_update_strategy
 
   target_pools = var.instance_group_target_pools
   target_size  = var.cluster_size


### PR DESCRIPTION
Using the latest google provider 3.54.0 will have the following errors:

Error: Unsupported argument

  on .terraform/modules/vault_cluster/modules/vault-cluster/main.tf line 60, in resource "google_compute_region_instance_group_manager" "vault":
  60:   instance_template  = data.template_file.compute_instance_template_self_link.rendered

An argument named "instance_template" is not expected here.


Error: Unsupported argument

  on .terraform/modules/vault_cluster/modules/vault-cluster/main.tf line 66, in resource "google_compute_region_instance_group_manager" "vault":
  66:   update_strategy = var.instance_group_update_strategy

An argument named "update_strategy" is not expected here.

update_strategy was documented in 
https://registry.terraform.io/providers/hashicorp/google/latest/docs/guides/version_2_upgrade